### PR TITLE
feat: add support for redis auth

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     }
     implementation 'io.grpc:grpc-all:1.55.1'
     implementation group: 'org.slf4j', name: 'jul-to-slf4j', version: '1.7.35'
-    implementation group: 'redis.clients', name: 'jedis', version: '3.0.1'
+    implementation group: 'redis.clients', name: 'jedis', version: '3.10.0'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.5'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
     implementation 'org.json:json:20230227'

--- a/src/main/java/com/gotocompany/depot/config/RedisSinkConfig.java
+++ b/src/main/java/com/gotocompany/depot/config/RedisSinkConfig.java
@@ -1,9 +1,11 @@
 package com.gotocompany.depot.config;
 
+import com.gotocompany.depot.config.converter.EmptyStringToNull;
 import com.gotocompany.depot.config.converter.JsonToPropertiesConverter;
 import com.gotocompany.depot.config.converter.RedisSinkDataTypeConverter;
 import com.gotocompany.depot.config.converter.RedisSinkDeploymentTypeConverter;
 import com.gotocompany.depot.config.converter.RedisSinkTtlTypeConverter;
+import com.gotocompany.depot.config.preprocessor.Trim;
 import com.gotocompany.depot.redis.enums.RedisSinkDataType;
 import com.gotocompany.depot.redis.enums.RedisSinkDeploymentType;
 import com.gotocompany.depot.redis.enums.RedisSinkTtlType;
@@ -13,9 +15,22 @@ import java.util.Properties;
 
 
 @Config.DisableFeature(Config.DisableableFeature.PARAMETER_FORMATTING)
+@Config.PreprocessorClasses({Trim.class})
 public interface RedisSinkConfig extends SinkConfig {
     @Key("SINK_REDIS_URLS")
     String getSinkRedisUrls();
+
+    @Key("SINK_REDIS_CLUSTER_MAX_ATTEMPTS")
+    @DefaultValue("5")
+    int getSinkRedisMaxAttempts();
+
+    @Key("SINK_REDIS_AUTH_USERNAME")
+    @ConverterClass(EmptyStringToNull.class)
+    String getSinkRedisAuthUsername();
+
+    @Key("SINK_REDIS_AUTH_PASSWORD")
+    @ConverterClass(EmptyStringToNull.class)
+    String getSinkRedisAuthPassword();
 
     @Key("SINK_REDIS_KEY_TEMPLATE")
     String getSinkRedisKeyTemplate();

--- a/src/main/java/com/gotocompany/depot/config/converter/EmptyStringToNull.java
+++ b/src/main/java/com/gotocompany/depot/config/converter/EmptyStringToNull.java
@@ -1,0 +1,15 @@
+package com.gotocompany.depot.config.converter;
+
+import org.aeonbits.owner.Converter;
+
+import java.lang.reflect.Method;
+
+public class EmptyStringToNull implements Converter<String> {
+    @Override
+    public String convert(Method method, String input) {
+        if (input.isEmpty()) {
+            return null;
+        }
+        return input;
+    }
+}

--- a/src/main/java/com/gotocompany/depot/config/preprocessor/Trim.java
+++ b/src/main/java/com/gotocompany/depot/config/preprocessor/Trim.java
@@ -1,0 +1,10 @@
+package com.gotocompany.depot.config.preprocessor;
+
+import org.aeonbits.owner.Preprocessor;
+
+public class Trim implements Preprocessor {
+    @Override
+    public String process(String input) {
+        return input == null ? null : input.trim();
+    }
+}

--- a/src/test/java/com/gotocompany/depot/config/RedisSinkConfigTest.java
+++ b/src/test/java/com/gotocompany/depot/config/RedisSinkConfigTest.java
@@ -6,6 +6,8 @@ import org.aeonbits.owner.ConfigFactory;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Properties;
+
 public class RedisSinkConfigTest {
     @Test
     public void testMetadataTypes() {
@@ -16,5 +18,43 @@ public class RedisSinkConfigTest {
         Assert.assertEquals("test-key", config.getSinkRedisKeyTemplate());
         Assert.assertEquals(RedisSinkDeploymentType.STANDALONE, config.getSinkRedisDeploymentType());
         Assert.assertEquals(RedisSinkTtlType.DISABLE, config.getSinkRedisTtlType());
+    }
+
+    @Test
+    public void shouldSetNullIfAuthConfigsSetAsEmptyString() {
+        Properties properties = new Properties();
+        properties.setProperty("SINK_REDIS_AUTH_USERNAME", "");
+        properties.setProperty("SINK_REDIS_AUTH_PASSWORD", "");
+        RedisSinkConfig config = ConfigFactory.create(RedisSinkConfig.class, properties);
+        Assert.assertNull(config.getSinkRedisAuthUsername());
+        Assert.assertNull(config.getSinkRedisAuthPassword());
+    }
+    @Test
+    public void shouldReturnNullIfAuthConfigsNotSet() {
+        Properties properties = new Properties();
+        RedisSinkConfig config = ConfigFactory.create(RedisSinkConfig.class, properties);
+        Assert.assertNull(config.getSinkRedisAuthUsername());
+        Assert.assertNull(config.getSinkRedisAuthPassword());
+    }
+
+    @Test
+    public void shouldReturnConfigsIfAuthConfigsNotEmpty() {
+        Properties properties = new Properties();
+        properties.setProperty("SINK_REDIS_AUTH_USERNAME", "user");
+        properties.setProperty("SINK_REDIS_AUTH_PASSWORD", "pwd");
+        RedisSinkConfig config = ConfigFactory.create(RedisSinkConfig.class, properties);
+        Assert.assertEquals("user", config.getSinkRedisAuthUsername());
+        Assert.assertEquals("pwd", config.getSinkRedisAuthPassword());
+    }
+
+    @Test
+    public void shouldRemoveWhiteSpacesFromConfigs() {
+        Properties properties = new Properties();
+        properties.setProperty("SINK_REDIS_URLS", "     0.0.0.0:8000      ");
+        properties.setProperty("SINK_REDIS_AUTH_USERNAME", " user ");
+        RedisSinkConfig config = ConfigFactory.create(RedisSinkConfig.class, properties);
+        Assert.assertEquals("0.0.0.0:8000", config.getSinkRedisUrls());
+        Assert.assertEquals("user", config.getSinkRedisAuthUsername());
+        Assert.assertNull(config.getSinkRedisAuthPassword());
     }
 }

--- a/src/test/java/com/gotocompany/depot/redis/client/RedisClientFactoryTest.java
+++ b/src/test/java/com/gotocompany/depot/redis/client/RedisClientFactoryTest.java
@@ -28,28 +28,6 @@ public class RedisClientFactoryTest {
     private StatsDReporter statsDReporter;
 
     @Test
-    public void shouldGetStandaloneClient() {
-        when(redisSinkConfig.getSinkRedisTtlType()).thenReturn(RedisSinkTtlType.DURATION);
-        when(redisSinkConfig.getSinkRedisDeploymentType()).thenReturn(RedisSinkDeploymentType.STANDALONE);
-        when(redisSinkConfig.getSinkRedisUrls()).thenReturn("0.0.0.0:0");
-
-        RedisClient client = RedisClientFactory.getClient(redisSinkConfig, statsDReporter);
-
-        Assert.assertEquals(RedisStandaloneClient.class, client.getClass());
-    }
-
-    @Test
-    public void shouldGetStandaloneClientWhenURLHasSpaces() {
-        when(redisSinkConfig.getSinkRedisTtlType()).thenReturn(RedisSinkTtlType.DURATION);
-        when(redisSinkConfig.getSinkRedisDeploymentType()).thenReturn(RedisSinkDeploymentType.STANDALONE);
-        when(redisSinkConfig.getSinkRedisUrls()).thenReturn(" 0.0.0.0:0 ");
-
-        RedisClient client = RedisClientFactory.getClient(redisSinkConfig, statsDReporter);
-
-        Assert.assertEquals(RedisStandaloneClient.class, client.getClass());
-    }
-
-    @Test
     public void shouldGetClusterClient() {
         when(redisSinkConfig.getSinkRedisTtlType()).thenReturn(RedisSinkTtlType.DURATION);
         when(redisSinkConfig.getSinkRedisDeploymentType()).thenReturn(RedisSinkDeploymentType.CLUSTER);


### PR DESCRIPTION
Update jedis client from 3.0.1 to 3.10.0.

Redis allows acl in following ways.
In redis config, acl can be configured with
1. Both username and password. eg: `user <user_name> ..<acls>.. on >somepassword`
2. Only username with no password. eg: `user <user_name> ..<acls>.. on nopass`
3. Only password via `requirepass` config. eg: `requirepass foobar`

Jedis client checks for `null` to decide whether to send AUTH command or not. We send nulls if username and password are not configured. For second case user can send any password but not empty string. Because Jedis client sends either `AUTH username password` or `AUTH password`