### PR TITLE
Enable publish to maven local -  ./gradlew publishToMavenLocal -Plocal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -178,7 +178,9 @@ publishing {
 }
 
 signing {
-   sign publishing.publications.maven
+    if (!project.hasProperty('local')) {
+        sign publishing.publications.maven
+    }
 }
 
 nexusPublishing {


### PR DESCRIPTION
## Problem:

> Task :signMavenPublication FAILED

FAILURE: Build failed with an exception.

 * What went wrong:
 Execution failed for task ':signMavenPublication'.
 > Cannot perform signing task ':signMavenPublication' because it has no configured signatory

## Solution:

This MR disables signing for local publishing, pass local parameter for local maven publish.
```
 ./gradlew publishToMavenLocal -Plocal
```