### PR TITLE
fix: Add non-retryable and retryable error handling in insert manager

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     implementation(group: 'com.google.cloud', name: 'google-cloud-bigtable', version: '2.24.1') {
         exclude group: "io.grpc"
     }
-    implementation (group: 'com.aliyun.odps', name: 'odps-sdk-core', version: '0.51.0-public') {
+    implementation (group: 'com.aliyun.odps', name: 'odps-sdk-core', version: '0.51.3-public') {
         exclude group: "com.google"
         exclude group: "io.grpc"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
 }
 
 group 'com.gotocompany'
-version '0.10.1'
+version '0.10.2'
 
 repositories {
     mavenLocal()

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     implementation (group: 'com.aliyun.odps', name: 'odps-sdk-core', version: '0.51.3-public') {
         exclude group: "com.google"
         exclude group: "io.grpc"
+        exclude group: "org.slf4j"
     }
     implementation 'io.grpc:grpc-all:1.55.1'
     implementation group: 'org.slf4j', name: 'jul-to-slf4j', version: '1.7.35'

--- a/src/main/java/com/gotocompany/depot/maxcompute/MaxComputeSink.java
+++ b/src/main/java/com/gotocompany/depot/maxcompute/MaxComputeSink.java
@@ -1,5 +1,6 @@
 package com.gotocompany.depot.maxcompute;
 
+import com.aliyun.odps.exceptions.SchemaMismatchException;
 import com.aliyun.odps.tunnel.TunnelException;
 import com.gotocompany.depot.Sink;
 import com.gotocompany.depot.SinkResponse;
@@ -56,6 +57,10 @@ public class MaxComputeSink implements Sink {
             sinkResponse.addErrors(recordWrappers.getValidRecords().stream().map(RecordWrapper::getIndex).collect(Collectors.toList()), new ErrorInfo(e, ErrorType.SINK_NON_RETRYABLE_ERROR));
             instrumentation.incrementCounter(maxComputeMetrics.getMaxComputeOperationTotalMetric(),
                     String.format(MaxComputeMetrics.MAXCOMPUTE_ERROR_TAG, e.getClass().getSimpleName()));
+            if (e.getCause() instanceof SchemaMismatchException) {
+                instrumentation.incrementCounter(maxComputeMetrics.getMaxComputeOperationTotalMetric(),
+                        String.format(MaxComputeMetrics.MAXCOMPUTE_ERROR_TAG, SchemaMismatchException.class.getSimpleName()));
+            }
         } catch (IOException | TunnelException e) {
             log.error("Error while inserting records to MaxCompute: ", e);
             sinkResponse.addErrors(recordWrappers.getValidRecords().stream().map(RecordWrapper::getIndex).collect(Collectors.toList()), new ErrorInfo(e, ErrorType.SINK_RETRYABLE_ERROR));

--- a/src/main/java/com/gotocompany/depot/maxcompute/client/insert/InsertManager.java
+++ b/src/main/java/com/gotocompany/depot/maxcompute/client/insert/InsertManager.java
@@ -102,7 +102,7 @@ public abstract class InsertManager {
             throw new NonRetryableException("Record pack schema Mismatch", e);
         } catch (IOException e) {
             log.info("IOException occurs, refreshing the schema", e);
-            streamingSessionManager.refreshSession(sessionKey);
+            streamingSessionManager.invalidateAllSessionCache();
             throw e;
         }
     }

--- a/src/main/java/com/gotocompany/depot/maxcompute/client/insert/InsertManager.java
+++ b/src/main/java/com/gotocompany/depot/maxcompute/client/insert/InsertManager.java
@@ -101,7 +101,7 @@ public abstract class InsertManager {
             log.error("Record pack schema Mismatch", e);
             throw new NonRetryableException("Record pack schema Mismatch", e);
         } catch (IOException e) {
-            log.info("IOException occurs, refreshing the schema", e);
+            log.info("IOException occurs, refreshing the sessions", e);
             streamingSessionManager.refreshAllSessions();
             throw e;
         }
@@ -124,7 +124,7 @@ public abstract class InsertManager {
             log.error("Record pack schema Mismatch", e);
             throw new NonRetryableException("Record pack schema Mismatch", e);
         } catch (IOException e) {
-            log.info("TunnelException occurs, refreshing the schema", e);
+            log.info("TunnelException occurs, refreshing the sessions", e);
             streamingSessionManager.refreshAllSessions();
             throw e;
         }

--- a/src/main/java/com/gotocompany/depot/maxcompute/client/insert/InsertManager.java
+++ b/src/main/java/com/gotocompany/depot/maxcompute/client/insert/InsertManager.java
@@ -102,7 +102,7 @@ public abstract class InsertManager {
             throw new NonRetryableException("Record pack schema Mismatch", e);
         } catch (IOException e) {
             log.info("IOException occurs, refreshing the schema", e);
-            streamingSessionManager.invalidateAllSessionCache();
+            streamingSessionManager.refreshAllSessions();
             throw e;
         }
     }
@@ -125,7 +125,7 @@ public abstract class InsertManager {
             throw new NonRetryableException("Record pack schema Mismatch", e);
         } catch (IOException e) {
             log.info("TunnelException occurs, refreshing the schema", e);
-            streamingSessionManager.invalidateAllSessionCache();
+            streamingSessionManager.refreshAllSessions();
             throw e;
         }
     }

--- a/src/main/java/com/gotocompany/depot/maxcompute/client/insert/InsertManager.java
+++ b/src/main/java/com/gotocompany/depot/maxcompute/client/insert/InsertManager.java
@@ -10,7 +10,6 @@ import com.gotocompany.depot.maxcompute.client.insert.session.StreamingSessionMa
 import com.gotocompany.depot.maxcompute.model.RecordWrapper;
 import com.gotocompany.depot.metrics.Instrumentation;
 import com.gotocompany.depot.metrics.MaxComputeMetrics;
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -20,15 +19,14 @@ import java.util.List;
 /**
  * InsertManager is responsible for inserting records into MaxCompute.
  */
-@Getter
 @Slf4j
 public abstract class InsertManager {
 
     private final MaxComputeSinkConfig maxComputeSinkConfig;
     private final Instrumentation instrumentation;
     private final MaxComputeMetrics maxComputeMetrics;
-    private final StreamingSessionManager streamingSessionManager;
     private final TableTunnel.FlushOption flushOption;
+    protected final StreamingSessionManager streamingSessionManager;
 
     protected InsertManager(MaxComputeSinkConfig maxComputeSinkConfig, Instrumentation instrumentation,
                             MaxComputeMetrics maxComputeMetrics,

--- a/src/main/java/com/gotocompany/depot/maxcompute/client/insert/InsertManager.java
+++ b/src/main/java/com/gotocompany/depot/maxcompute/client/insert/InsertManager.java
@@ -1,14 +1,17 @@
 package com.gotocompany.depot.maxcompute.client.insert;
 
+import com.aliyun.odps.exceptions.SchemaMismatchException;
 import com.aliyun.odps.tunnel.TableTunnel;
 import com.aliyun.odps.tunnel.TunnelException;
 import com.aliyun.odps.tunnel.io.CompressOption;
 import com.gotocompany.depot.config.MaxComputeSinkConfig;
+import com.gotocompany.depot.exception.NonRetryableException;
+import com.gotocompany.depot.maxcompute.client.insert.session.StreamingSessionManager;
 import com.gotocompany.depot.maxcompute.model.RecordWrapper;
 import com.gotocompany.depot.metrics.Instrumentation;
 import com.gotocompany.depot.metrics.MaxComputeMetrics;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -17,13 +20,26 @@ import java.util.List;
 /**
  * InsertManager is responsible for inserting records into MaxCompute.
  */
-@RequiredArgsConstructor
 @Getter
+@Slf4j
 public abstract class InsertManager {
 
     private final MaxComputeSinkConfig maxComputeSinkConfig;
     private final Instrumentation instrumentation;
     private final MaxComputeMetrics maxComputeMetrics;
+    private final StreamingSessionManager streamingSessionManager;
+    private final TableTunnel.FlushOption flushOption;
+
+    protected InsertManager(MaxComputeSinkConfig maxComputeSinkConfig, Instrumentation instrumentation,
+                            MaxComputeMetrics maxComputeMetrics,
+                            StreamingSessionManager streamingSessionManager) {
+        this.maxComputeSinkConfig = maxComputeSinkConfig;
+        this.instrumentation = instrumentation;
+        this.maxComputeMetrics = maxComputeMetrics;
+        this.streamingSessionManager = streamingSessionManager;
+        this.flushOption = new TableTunnel.FlushOption()
+                .timeout(maxComputeSinkConfig.getMaxComputeRecordPackFlushTimeoutMs());
+    }
 
     /**
      * Insert records into MaxCompute.
@@ -57,7 +73,7 @@ public abstract class InsertManager {
      * @param start start time of the operation
      * @param flushResult result of the flush operation
      */
-    protected void instrument(Instant start, TableTunnel.FlushResult flushResult) {
+    private void instrument(Instant start, TableTunnel.FlushResult flushResult) {
         instrumentation.incrementCounter(maxComputeMetrics.getMaxComputeOperationTotalMetric(),
                 String.format(MaxComputeMetrics.MAXCOMPUTE_API_TAG, MaxComputeMetrics.MaxComputeAPIType.TABLE_INSERT));
         instrumentation.captureDurationSince(maxComputeMetrics.getMaxComputeOperationLatencyMetric(), start,
@@ -66,6 +82,52 @@ public abstract class InsertManager {
                 String.format(MaxComputeMetrics.MAXCOMPUTE_COMPRESSION_TAG, maxComputeSinkConfig.isStreamingInsertCompressEnabled(), maxComputeSinkConfig.getMaxComputeCompressionAlgorithm()));
         instrumentation.captureCount(maxComputeMetrics.getMaxComputeFlushSizeMetric(), flushResult.getFlushSize(),
                 String.format(MaxComputeMetrics.MAXCOMPUTE_COMPRESSION_TAG, maxComputeSinkConfig.isStreamingInsertCompressEnabled(), maxComputeSinkConfig.getMaxComputeCompressionAlgorithm()));
+    }
+
+    /**
+     * Append a record to the record pack.
+     * When schema mismatch occurs, wrap the exception in a NonRetryableException. It is not possible to recover from schema mismatch.
+     * When network partition occurs, refresh the schema and rethrow the exception.
+     *
+     * @param recordPack recordPack to append the record to
+     * @param recordWrapper record to append
+     * @param sessionKey key to identify the session, used for refreshing the schema
+     * @throws IOException typically thrown when issues such as network partition occur
+     */
+    protected void appendRecord(TableTunnel.StreamRecordPack recordPack, RecordWrapper recordWrapper, String sessionKey) throws IOException {
+        try {
+            recordPack.append(recordWrapper.getRecord());
+        } catch (SchemaMismatchException e) {
+            log.error("Record pack schema Mismatch", e);
+            throw new NonRetryableException("Record pack schema Mismatch", e);
+        } catch (IOException e) {
+            log.info("IOException occurs, refreshing the schema", e);
+            streamingSessionManager.refreshSession(sessionKey);
+            throw e;
+        }
+    }
+
+    /**
+     * Flush the record pack.
+     * When schema mismatch occurs, wrap the exception in a NonRetryableException. It is not possible to recover from schema mismatch.
+     * When network partition occurs, typically indicated by IOException being thrown, refresh the schema and rethrow the exception.
+     *
+     * @param recordPack recordPack to flush
+     * @throws IOException typically thrown when issues such as network partition occur
+     */
+    protected void flushRecordPack(TableTunnel.StreamRecordPack recordPack) throws IOException {
+        Instant start = Instant.now();
+        try {
+            TableTunnel.FlushResult flushResult = recordPack.flush(flushOption);
+            instrument(start, flushResult);
+        } catch (SchemaMismatchException e) {
+            log.error("Record pack schema Mismatch", e);
+            throw new NonRetryableException("Record pack schema Mismatch", e);
+        } catch (IOException e) {
+            log.info("TunnelException occurs, refreshing the schema", e);
+            streamingSessionManager.invalidateAllSessionCache();
+            throw e;
+        }
     }
 
 }

--- a/src/main/java/com/gotocompany/depot/maxcompute/client/insert/InsertManager.java
+++ b/src/main/java/com/gotocompany/depot/maxcompute/client/insert/InsertManager.java
@@ -10,6 +10,7 @@ import com.gotocompany.depot.maxcompute.client.insert.session.StreamingSessionMa
 import com.gotocompany.depot.maxcompute.model.RecordWrapper;
 import com.gotocompany.depot.metrics.Instrumentation;
 import com.gotocompany.depot.metrics.MaxComputeMetrics;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -19,14 +20,15 @@ import java.util.List;
 /**
  * InsertManager is responsible for inserting records into MaxCompute.
  */
+@Getter
 @Slf4j
 public abstract class InsertManager {
 
     private final MaxComputeSinkConfig maxComputeSinkConfig;
     private final Instrumentation instrumentation;
     private final MaxComputeMetrics maxComputeMetrics;
+    private final StreamingSessionManager streamingSessionManager;
     private final TableTunnel.FlushOption flushOption;
-    protected final StreamingSessionManager streamingSessionManager;
 
     protected InsertManager(MaxComputeSinkConfig maxComputeSinkConfig, Instrumentation instrumentation,
                             MaxComputeMetrics maxComputeMetrics,

--- a/src/main/java/com/gotocompany/depot/maxcompute/client/insert/NonPartitionedInsertManager.java
+++ b/src/main/java/com/gotocompany/depot/maxcompute/client/insert/NonPartitionedInsertManager.java
@@ -37,12 +37,12 @@ public class NonPartitionedInsertManager extends InsertManager {
      */
     @Override
     public void insert(List<RecordWrapper> recordWrappers) throws TunnelException, IOException {
-        TableTunnel.StreamUploadSession streamUploadSession = super.getStreamingSessionManager().getSession(NON_PARTITIONED);
+        TableTunnel.StreamUploadSession streamUploadSession = streamingSessionManager.getSession(NON_PARTITIONED);
         TableTunnel.StreamRecordPack recordPack = newRecordPack(streamUploadSession);
         for (RecordWrapper recordWrapper : recordWrappers) {
-            super.appendRecord(recordPack, recordWrapper, NON_PARTITIONED);
+            appendRecord(recordPack, recordWrapper, NON_PARTITIONED);
         }
-        super.flushRecordPack(recordPack);
+        flushRecordPack(recordPack);
     }
 
 }

--- a/src/main/java/com/gotocompany/depot/maxcompute/client/insert/NonPartitionedInsertManager.java
+++ b/src/main/java/com/gotocompany/depot/maxcompute/client/insert/NonPartitionedInsertManager.java
@@ -37,12 +37,12 @@ public class NonPartitionedInsertManager extends InsertManager {
      */
     @Override
     public void insert(List<RecordWrapper> recordWrappers) throws TunnelException, IOException {
-        TableTunnel.StreamUploadSession streamUploadSession = streamingSessionManager.getSession(NON_PARTITIONED);
+        TableTunnel.StreamUploadSession streamUploadSession = super.getStreamingSessionManager().getSession(NON_PARTITIONED);
         TableTunnel.StreamRecordPack recordPack = newRecordPack(streamUploadSession);
         for (RecordWrapper recordWrapper : recordWrappers) {
-            appendRecord(recordPack, recordWrapper, NON_PARTITIONED);
+            super.appendRecord(recordPack, recordWrapper, NON_PARTITIONED);
         }
-        flushRecordPack(recordPack);
+        super.flushRecordPack(recordPack);
     }
 
 }

--- a/src/main/java/com/gotocompany/depot/maxcompute/client/insert/PartitionedInsertManager.java
+++ b/src/main/java/com/gotocompany/depot/maxcompute/client/insert/PartitionedInsertManager.java
@@ -40,12 +40,12 @@ public class PartitionedInsertManager extends InsertManager {
         Map<String, List<RecordWrapper>> partitionSpecRecordWrapperMap = recordWrappers.stream()
                 .collect(Collectors.groupingBy(record -> record.getPartitionSpec().toString()));
         for (Map.Entry<String, List<RecordWrapper>> entry : partitionSpecRecordWrapperMap.entrySet()) {
-            TableTunnel.StreamUploadSession streamUploadSession = super.getStreamingSessionManager().getSession(entry.getKey());
+            TableTunnel.StreamUploadSession streamUploadSession = streamingSessionManager.getSession(entry.getKey());
             TableTunnel.StreamRecordPack recordPack = newRecordPack(streamUploadSession);
             for (RecordWrapper recordWrapper : entry.getValue()) {
-                super.appendRecord(recordPack, recordWrapper, recordWrapper.getPartitionSpec().toString());
+                appendRecord(recordPack, recordWrapper, recordWrapper.getPartitionSpec().toString());
             }
-            super.flushRecordPack(recordPack);
+            flushRecordPack(recordPack);
         }
     }
 

--- a/src/main/java/com/gotocompany/depot/maxcompute/client/insert/PartitionedInsertManager.java
+++ b/src/main/java/com/gotocompany/depot/maxcompute/client/insert/PartitionedInsertManager.java
@@ -40,12 +40,12 @@ public class PartitionedInsertManager extends InsertManager {
         Map<String, List<RecordWrapper>> partitionSpecRecordWrapperMap = recordWrappers.stream()
                 .collect(Collectors.groupingBy(record -> record.getPartitionSpec().toString()));
         for (Map.Entry<String, List<RecordWrapper>> entry : partitionSpecRecordWrapperMap.entrySet()) {
-            TableTunnel.StreamUploadSession streamUploadSession = streamingSessionManager.getSession(entry.getKey());
+            TableTunnel.StreamUploadSession streamUploadSession = super.getStreamingSessionManager().getSession(entry.getKey());
             TableTunnel.StreamRecordPack recordPack = newRecordPack(streamUploadSession);
             for (RecordWrapper recordWrapper : entry.getValue()) {
-                appendRecord(recordPack, recordWrapper, recordWrapper.getPartitionSpec().toString());
+                super.appendRecord(recordPack, recordWrapper, recordWrapper.getPartitionSpec().toString());
             }
-            flushRecordPack(recordPack);
+            super.flushRecordPack(recordPack);
         }
     }
 

--- a/src/main/java/com/gotocompany/depot/maxcompute/client/insert/session/StreamingSessionManager.java
+++ b/src/main/java/com/gotocompany/depot/maxcompute/client/insert/session/StreamingSessionManager.java
@@ -105,8 +105,10 @@ public final class StreamingSessionManager {
     /**
      * Invalidate all the sessions in the cache.
      */
-    public void invalidateAllSessionCache() {
-        sessionCache.invalidateAll();
+    public void refreshAllSessions() {
+        sessionCache.asMap()
+                .keySet()
+                .forEach(sessionCache::refresh);
     }
 
     private static TableTunnel.StreamUploadSession buildStreamSession(TableTunnel.StreamUploadSession.Builder streamUploadSessionBuilder,

--- a/src/main/java/com/gotocompany/depot/maxcompute/client/insert/session/StreamingSessionManager.java
+++ b/src/main/java/com/gotocompany/depot/maxcompute/client/insert/session/StreamingSessionManager.java
@@ -102,6 +102,13 @@ public final class StreamingSessionManager {
         sessionCache.refresh(partitionSpec);
     }
 
+    /**
+     * Invalidate all the sessions in the cache.
+     */
+    public void invalidateAllSessionCache() {
+        sessionCache.invalidateAll();
+    }
+
     private static TableTunnel.StreamUploadSession buildStreamSession(TableTunnel.StreamUploadSession.Builder streamUploadSessionBuilder,
                                                                       Instrumentation instrumentation,
                                                                       MaxComputeMetrics maxComputeMetrics) throws TunnelException {

--- a/src/main/java/com/gotocompany/depot/maxcompute/record/ProtoDataColumnRecordDecorator.java
+++ b/src/main/java/com/gotocompany/depot/maxcompute/record/ProtoDataColumnRecordDecorator.java
@@ -31,7 +31,7 @@ public class ProtoDataColumnRecordDecorator extends RecordDecorator {
     private final ProtobufConverterOrchestrator protobufConverterOrchestrator;
     private final MessageParser protoMessageParser;
     private final PartitioningStrategy partitioningStrategy;
-    private final SinkConfig sinkConfig;
+    private final SinkConnectorSchemaMessageMode sinkConnectorSchemaMessageMode;
     private final String partitionFieldName;
     private final boolean shouldReplaceOriginalColumn;
     private final String schemaClass;
@@ -52,7 +52,7 @@ public class ProtoDataColumnRecordDecorator extends RecordDecorator {
         this.protobufConverterOrchestrator = protobufConverterOrchestrator;
         this.protoMessageParser = messageParser;
         this.partitioningStrategy = partitioningStrategy;
-        this.sinkConfig = sinkConfig;
+        this.sinkConnectorSchemaMessageMode = sinkConfig.getSinkConnectorSchemaMessageMode();
         this.partitionFieldName = Optional.ofNullable(partitioningStrategy)
                 .map(PartitioningStrategy::getOriginalPartitionColumnName)
                 .orElse(null);
@@ -78,7 +78,7 @@ public class ProtoDataColumnRecordDecorator extends RecordDecorator {
      */
     @Override
     public RecordWrapper process(RecordWrapper recordWrapper, Message message) throws IOException {
-        ParsedMessage parsedMessage = protoMessageParser.parse(message, sinkConfig.getSinkConnectorSchemaMessageMode(), schemaClass);
+        ParsedMessage parsedMessage = protoMessageParser.parse(message, sinkConnectorSchemaMessageMode, schemaClass);
         if (!sinkConnectorSchemaProtoAllowUnknownFieldsEnable) {
             Instant unknownFieldValidationStart = Instant.now();
             parsedMessage.validate(protoUnknownFieldValidationType);

--- a/src/test/java/com/gotocompany/depot/maxcompute/client/insert/NonPartitionedInsertManagerTest.java
+++ b/src/test/java/com/gotocompany/depot/maxcompute/client/insert/NonPartitionedInsertManagerTest.java
@@ -225,10 +225,13 @@ public class NonPartitionedInsertManagerTest {
                 Mockito.mock(RecordWrapper.class)
         );
 
-        nonPartitionedInsertManager.insert(recordWrappers);
-
-        verify(streamingSessionManager, Mockito.times(1))
-                .refreshSession(Mockito.any());
+        try {
+            nonPartitionedInsertManager.insert(recordWrappers);
+        } catch (IOException e) {
+            verify(streamingSessionManager, Mockito.times(1))
+                    .invalidateAllSessionCache();
+            throw e;
+        }
     }
 
     @Test(expected = NonRetryableException.class)
@@ -355,10 +358,13 @@ public class NonPartitionedInsertManagerTest {
                 Mockito.mock(RecordWrapper.class)
         );
 
-        nonPartitionedInsertManager.insert(recordWrappers);
-
-        verify(streamingSessionManager, Mockito.times(1))
-                .invalidateAllSessionCache();
+        try {
+            nonPartitionedInsertManager.insert(recordWrappers);
+        } catch (IOException e) {
+            verify(streamingSessionManager, Mockito.times(1))
+                    .invalidateAllSessionCache();
+            throw e;
+        }
     }
 
     @Test(expected = NonRetryableException.class)

--- a/src/test/java/com/gotocompany/depot/maxcompute/client/insert/NonPartitionedInsertManagerTest.java
+++ b/src/test/java/com/gotocompany/depot/maxcompute/client/insert/NonPartitionedInsertManagerTest.java
@@ -358,7 +358,7 @@ public class NonPartitionedInsertManagerTest {
         nonPartitionedInsertManager.insert(recordWrappers);
 
         verify(streamingSessionManager, Mockito.times(1))
-                .refreshSession(Mockito.any());
+                .invalidateAllSessionCache();
     }
 
     @Test(expected = NonRetryableException.class)

--- a/src/test/java/com/gotocompany/depot/maxcompute/client/insert/NonPartitionedInsertManagerTest.java
+++ b/src/test/java/com/gotocompany/depot/maxcompute/client/insert/NonPartitionedInsertManagerTest.java
@@ -229,7 +229,7 @@ public class NonPartitionedInsertManagerTest {
             nonPartitionedInsertManager.insert(recordWrappers);
         } catch (IOException e) {
             verify(streamingSessionManager, Mockito.times(1))
-                    .invalidateAllSessionCache();
+                    .refreshAllSessions();
             throw e;
         }
     }
@@ -362,7 +362,7 @@ public class NonPartitionedInsertManagerTest {
             nonPartitionedInsertManager.insert(recordWrappers);
         } catch (IOException e) {
             verify(streamingSessionManager, Mockito.times(1))
-                    .invalidateAllSessionCache();
+                    .refreshAllSessions();
             throw e;
         }
     }

--- a/src/test/java/com/gotocompany/depot/maxcompute/client/insert/PartitionedInsertManagerTest.java
+++ b/src/test/java/com/gotocompany/depot/maxcompute/client/insert/PartitionedInsertManagerTest.java
@@ -183,7 +183,7 @@ public class PartitionedInsertManagerTest {
     }
 
     @Test(expected = IOException.class)
-    public void shouldRefreshSessionWhenIOExceptionOccurredDuringRecordAppend() throws IOException, TunnelException {
+    public void shouldInvalidateAllSessionSessionWhenIOExceptionOccurredDuringRecordAppend() throws IOException, TunnelException {
         TableTunnel.FlushResult flushResult = Mockito.mock(TableTunnel.FlushResult.class);
         when(flushResult.getRecordCount())
                 .thenReturn(2L);
@@ -251,10 +251,13 @@ public class PartitionedInsertManagerTest {
         PartitionedInsertManager partitionedInsertManager = new PartitionedInsertManager(maxComputeSinkConfig,
                 instrumentation, Mockito.mock(MaxComputeMetrics.class), streamingSessionManager);
 
-        partitionedInsertManager.insert(recordWrappers);
-
-        verify(streamingSessionManager, Mockito.times(1))
-                .refreshSession(Mockito.any());
+        try {
+            partitionedInsertManager.insert(recordWrappers);
+        } catch (IOException e) {
+            verify(streamingSessionManager, Mockito.times(1))
+                    .invalidateAllSessionCache();
+            throw e;
+        }
     }
 
     @Test(expected = NonRetryableException.class)
@@ -403,7 +406,7 @@ public class PartitionedInsertManagerTest {
     }
 
     @Test(expected = IOException.class)
-    public void shouldRefreshSessionWhenIOExceptionOccurredDuringRecordFlush() throws IOException, TunnelException {
+    public void shouldInvalidateAllSessionSessionWhenIOExceptionOccurredDuringRecordFlush() throws IOException, TunnelException {
         TableTunnel.FlushResult flushResult = Mockito.mock(TableTunnel.FlushResult.class);
         when(flushResult.getRecordCount())
                 .thenReturn(2L);
@@ -470,10 +473,13 @@ public class PartitionedInsertManagerTest {
         PartitionedInsertManager partitionedInsertManager = new PartitionedInsertManager(maxComputeSinkConfig,
                 instrumentation, Mockito.mock(MaxComputeMetrics.class), streamingSessionManager);
 
-        partitionedInsertManager.insert(recordWrappers);
-
-        verify(streamingSessionManager, Mockito.times(1))
-                .invalidateAllSessionCache();
+        try {
+            partitionedInsertManager.insert(recordWrappers);
+        } catch (IOException e) {
+            verify(streamingSessionManager, Mockito.times(1))
+                    .invalidateAllSessionCache();
+            throw e;
+        }
     }
 
 }

--- a/src/test/java/com/gotocompany/depot/maxcompute/client/insert/PartitionedInsertManagerTest.java
+++ b/src/test/java/com/gotocompany/depot/maxcompute/client/insert/PartitionedInsertManagerTest.java
@@ -473,7 +473,7 @@ public class PartitionedInsertManagerTest {
         partitionedInsertManager.insert(recordWrappers);
 
         verify(streamingSessionManager, Mockito.times(1))
-                .refreshSession(Mockito.any());
+                .invalidateAllSessionCache();
     }
 
 }

--- a/src/test/java/com/gotocompany/depot/maxcompute/client/insert/PartitionedInsertManagerTest.java
+++ b/src/test/java/com/gotocompany/depot/maxcompute/client/insert/PartitionedInsertManagerTest.java
@@ -183,7 +183,7 @@ public class PartitionedInsertManagerTest {
     }
 
     @Test(expected = IOException.class)
-    public void shouldInvalidateAllSessionSessionWhenIOExceptionOccurredDuringRecordAppend() throws IOException, TunnelException {
+    public void shouldRefrehAllSessionSessionWhenIOExceptionOccurredDuringRecordAppend() throws IOException, TunnelException {
         TableTunnel.FlushResult flushResult = Mockito.mock(TableTunnel.FlushResult.class);
         when(flushResult.getRecordCount())
                 .thenReturn(2L);
@@ -255,7 +255,7 @@ public class PartitionedInsertManagerTest {
             partitionedInsertManager.insert(recordWrappers);
         } catch (IOException e) {
             verify(streamingSessionManager, Mockito.times(1))
-                    .invalidateAllSessionCache();
+                    .refreshAllSessions();
             throw e;
         }
     }
@@ -406,7 +406,7 @@ public class PartitionedInsertManagerTest {
     }
 
     @Test(expected = IOException.class)
-    public void shouldInvalidateAllSessionSessionWhenIOExceptionOccurredDuringRecordFlush() throws IOException, TunnelException {
+    public void shouldRefrehAllSessionSessionWhenIOExceptionOccurredDuringRecordFlush() throws IOException, TunnelException {
         TableTunnel.FlushResult flushResult = Mockito.mock(TableTunnel.FlushResult.class);
         when(flushResult.getRecordCount())
                 .thenReturn(2L);
@@ -477,7 +477,7 @@ public class PartitionedInsertManagerTest {
             partitionedInsertManager.insert(recordWrappers);
         } catch (IOException e) {
             verify(streamingSessionManager, Mockito.times(1))
-                    .invalidateAllSessionCache();
+                    .refreshAllSessions();
             throw e;
         }
     }

--- a/src/test/java/com/gotocompany/depot/maxcompute/client/insert/PartitionedInsertManagerTest.java
+++ b/src/test/java/com/gotocompany/depot/maxcompute/client/insert/PartitionedInsertManagerTest.java
@@ -1,10 +1,12 @@
 package com.gotocompany.depot.maxcompute.client.insert;
 
 import com.aliyun.odps.PartitionSpec;
+import com.aliyun.odps.exceptions.SchemaMismatchException;
 import com.aliyun.odps.tunnel.TableTunnel;
 import com.aliyun.odps.tunnel.TunnelException;
 import com.aliyun.odps.tunnel.io.CompressOption;
 import com.gotocompany.depot.config.MaxComputeSinkConfig;
+import com.gotocompany.depot.exception.NonRetryableException;
 import com.gotocompany.depot.maxcompute.client.insert.session.StreamingSessionManager;
 import com.gotocompany.depot.maxcompute.model.RecordWrapper;
 import com.gotocompany.depot.metrics.Instrumentation;
@@ -22,6 +24,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -180,7 +183,7 @@ public class PartitionedInsertManagerTest {
     }
 
     @Test(expected = IOException.class)
-    public void shouldRefreshSessionWhenIOExceptionOccurred() throws IOException, TunnelException {
+    public void shouldRefreshSessionWhenIOExceptionOccurredDuringRecordAppend() throws IOException, TunnelException {
         TableTunnel.FlushResult flushResult = Mockito.mock(TableTunnel.FlushResult.class);
         when(flushResult.getRecordCount())
                 .thenReturn(2L);
@@ -192,6 +195,225 @@ public class PartitionedInsertManagerTest {
         when(streamUploadSession.newRecordPack(compressOptionArgumentCaptor.capture()))
                 .thenReturn(streamRecordPack);
         Mockito.doThrow(new IOException())
+                .when(streamRecordPack)
+                .append(Mockito.any());
+        when(streamRecordPack.flush())
+                .thenReturn("traceId");
+        TableTunnel tableTunnel = Mockito.mock(TableTunnel.class);
+        TableTunnel.StreamUploadSession.Builder builder = Mockito.mock(TableTunnel.StreamUploadSession.Builder.class);
+        when(tableTunnel.buildStreamUploadSession(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(builder);
+        when(builder.setCreatePartition(Mockito.anyBoolean()))
+                .thenReturn(builder);
+        when(builder.setPartitionSpec(Mockito.anyString()))
+                .thenReturn(builder);
+        when(builder.allowSchemaMismatch(Mockito.anyBoolean()))
+                .thenReturn(builder);
+        when(builder.setSlotNum(Mockito.anyLong()))
+                .thenReturn(builder);
+        when(builder.build())
+                .thenReturn(streamUploadSession);
+        MaxComputeSinkConfig maxComputeSinkConfig = Mockito.mock(MaxComputeSinkConfig.class);
+        when(maxComputeSinkConfig.getMaxComputeProjectId())
+                .thenReturn("project");
+        when(maxComputeSinkConfig.getMaxComputeTableName())
+                .thenReturn("table");
+        when(maxComputeSinkConfig.getMaxComputeRecordPackFlushTimeoutMs())
+                .thenReturn(1000L);
+        when(maxComputeSinkConfig.isStreamingInsertCompressEnabled())
+                .thenReturn(true);
+        when(maxComputeSinkConfig.getMaxComputeCompressionAlgorithm())
+                .thenReturn(CompressOption.CompressAlgorithm.ODPS_RAW);
+        when(maxComputeSinkConfig.getMaxComputeCompressionLevel())
+                .thenReturn(1);
+        when(maxComputeSinkConfig.getMaxComputeCompressionStrategy())
+                .thenReturn(1);
+        when(maxComputeSinkConfig.getStreamingInsertMaximumSessionCount())
+                .thenReturn(1);
+        when(maxComputeSinkConfig.getStreamingInsertTunnelSlotCountPerSession())
+                .thenReturn(1L);
+        RecordWrapper firstPartitionRecordWrapper = Mockito.mock(RecordWrapper.class);
+        when(firstPartitionRecordWrapper.getPartitionSpec())
+                .thenReturn(new PartitionSpec("ds=1"));
+        RecordWrapper secondPartitionRecordWrapper = Mockito.mock(RecordWrapper.class);
+        when(secondPartitionRecordWrapper.getPartitionSpec())
+                .thenReturn(new PartitionSpec("ds=2"));
+        List<RecordWrapper> recordWrappers = Arrays.asList(
+                firstPartitionRecordWrapper,
+                secondPartitionRecordWrapper
+        );
+        doNothing()
+                .when(instrumentation)
+                .captureCount(Mockito.anyString(), Mockito.anyLong());
+        StreamingSessionManager streamingSessionManager = Mockito.spy(StreamingSessionManager.createPartitioned(
+                tableTunnel, maxComputeSinkConfig, instrumentation, Mockito.mock(MaxComputeMetrics.class)
+        ));
+        PartitionedInsertManager partitionedInsertManager = new PartitionedInsertManager(maxComputeSinkConfig,
+                instrumentation, Mockito.mock(MaxComputeMetrics.class), streamingSessionManager);
+
+        partitionedInsertManager.insert(recordWrappers);
+
+        verify(streamingSessionManager, Mockito.times(1))
+                .refreshSession(Mockito.any());
+    }
+
+    @Test(expected = NonRetryableException.class)
+    public void shouldWrapExceptionToNonRetryableExceptionWhenSchemaMismatchExceptionOccurredDuringRecordAppend() throws IOException, TunnelException {
+        TableTunnel.FlushResult flushResult = Mockito.mock(TableTunnel.FlushResult.class);
+        when(flushResult.getRecordCount())
+                .thenReturn(2L);
+        TableTunnel.StreamRecordPack streamRecordPack = Mockito.mock(TableTunnel.StreamRecordPack.class);
+        TableTunnel.StreamUploadSession streamUploadSession = Mockito.spy(TableTunnel.StreamUploadSession.class);
+        when(streamRecordPack.flush(Mockito.any(TableTunnel.FlushOption.class)))
+                .thenReturn(flushResult);
+        ArgumentCaptor<CompressOption> compressOptionArgumentCaptor = ArgumentCaptor.forClass(CompressOption.class);
+        when(streamUploadSession.newRecordPack(compressOptionArgumentCaptor.capture()))
+                .thenReturn(streamRecordPack);
+        Mockito.doThrow(new SchemaMismatchException("schema mismatch", "v1"))
+                .when(streamRecordPack)
+                .append(Mockito.any());
+        when(streamRecordPack.flush())
+                .thenReturn("traceId");
+        TableTunnel tableTunnel = Mockito.mock(TableTunnel.class);
+        TableTunnel.StreamUploadSession.Builder builder = Mockito.mock(TableTunnel.StreamUploadSession.Builder.class);
+        when(tableTunnel.buildStreamUploadSession(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(builder);
+        when(builder.setCreatePartition(Mockito.anyBoolean()))
+                .thenReturn(builder);
+        when(builder.setPartitionSpec(Mockito.anyString()))
+                .thenReturn(builder);
+        when(builder.allowSchemaMismatch(Mockito.anyBoolean()))
+                .thenReturn(builder);
+        when(builder.setSlotNum(Mockito.anyLong()))
+                .thenReturn(builder);
+        when(builder.build())
+                .thenReturn(streamUploadSession);
+        MaxComputeSinkConfig maxComputeSinkConfig = Mockito.mock(MaxComputeSinkConfig.class);
+        when(maxComputeSinkConfig.getMaxComputeProjectId())
+                .thenReturn("project");
+        when(maxComputeSinkConfig.getMaxComputeTableName())
+                .thenReturn("table");
+        when(maxComputeSinkConfig.getMaxComputeRecordPackFlushTimeoutMs())
+                .thenReturn(1000L);
+        when(maxComputeSinkConfig.isStreamingInsertCompressEnabled())
+                .thenReturn(true);
+        when(maxComputeSinkConfig.getMaxComputeCompressionAlgorithm())
+                .thenReturn(CompressOption.CompressAlgorithm.ODPS_RAW);
+        when(maxComputeSinkConfig.getMaxComputeCompressionLevel())
+                .thenReturn(1);
+        when(maxComputeSinkConfig.getMaxComputeCompressionStrategy())
+                .thenReturn(1);
+        when(maxComputeSinkConfig.getStreamingInsertMaximumSessionCount())
+                .thenReturn(1);
+        when(maxComputeSinkConfig.getStreamingInsertTunnelSlotCountPerSession())
+                .thenReturn(1L);
+        RecordWrapper firstPartitionRecordWrapper = Mockito.mock(RecordWrapper.class);
+        when(firstPartitionRecordWrapper.getPartitionSpec())
+                .thenReturn(new PartitionSpec("ds=1"));
+        RecordWrapper secondPartitionRecordWrapper = Mockito.mock(RecordWrapper.class);
+        when(secondPartitionRecordWrapper.getPartitionSpec())
+                .thenReturn(new PartitionSpec("ds=2"));
+        List<RecordWrapper> recordWrappers = Arrays.asList(
+                firstPartitionRecordWrapper,
+                secondPartitionRecordWrapper
+        );
+        doNothing()
+                .when(instrumentation)
+                .captureCount(Mockito.anyString(), Mockito.anyLong());
+        StreamingSessionManager streamingSessionManager = Mockito.spy(StreamingSessionManager.createPartitioned(
+                tableTunnel, maxComputeSinkConfig, instrumentation, Mockito.mock(MaxComputeMetrics.class)
+        ));
+        PartitionedInsertManager partitionedInsertManager = new PartitionedInsertManager(maxComputeSinkConfig,
+                instrumentation, Mockito.mock(MaxComputeMetrics.class), streamingSessionManager);
+
+        partitionedInsertManager.insert(recordWrappers);
+    }
+
+    @Test(expected = NonRetryableException.class)
+    public void shouldWrapToNonRetryableExceptionWhenSchemaMismatchHappensDuringFlush() throws IOException, TunnelException {
+        TableTunnel.FlushResult flushResult = Mockito.mock(TableTunnel.FlushResult.class);
+        when(flushResult.getRecordCount())
+                .thenReturn(2L);
+        TableTunnel.StreamRecordPack streamRecordPack = Mockito.mock(TableTunnel.StreamRecordPack.class);
+        TableTunnel.StreamUploadSession streamUploadSession = Mockito.spy(TableTunnel.StreamUploadSession.class);
+        doThrow(new SchemaMismatchException("schema mismatch", "v1"))
+                .when(streamRecordPack)
+                .flush(Mockito.any());
+        ArgumentCaptor<CompressOption> compressOptionArgumentCaptor = ArgumentCaptor.forClass(CompressOption.class);
+        when(streamUploadSession.newRecordPack(compressOptionArgumentCaptor.capture()))
+                .thenReturn(streamRecordPack);
+        Mockito.doNothing()
+                .when(streamRecordPack)
+                .append(Mockito.any());
+        when(streamRecordPack.flush())
+                .thenReturn("traceId");
+        TableTunnel tableTunnel = Mockito.mock(TableTunnel.class);
+        TableTunnel.StreamUploadSession.Builder builder = Mockito.mock(TableTunnel.StreamUploadSession.Builder.class);
+        when(tableTunnel.buildStreamUploadSession(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(builder);
+        when(builder.setCreatePartition(Mockito.anyBoolean()))
+                .thenReturn(builder);
+        when(builder.setPartitionSpec(Mockito.anyString()))
+                .thenReturn(builder);
+        when(builder.allowSchemaMismatch(Mockito.anyBoolean()))
+                .thenReturn(builder);
+        when(builder.setSlotNum(Mockito.anyLong()))
+                .thenReturn(builder);
+        when(builder.build())
+                .thenReturn(streamUploadSession);
+        MaxComputeSinkConfig maxComputeSinkConfig = Mockito.mock(MaxComputeSinkConfig.class);
+        when(maxComputeSinkConfig.getMaxComputeProjectId())
+                .thenReturn("project");
+        when(maxComputeSinkConfig.getMaxComputeTableName())
+                .thenReturn("table");
+        when(maxComputeSinkConfig.getMaxComputeRecordPackFlushTimeoutMs())
+                .thenReturn(1000L);
+        when(maxComputeSinkConfig.isStreamingInsertCompressEnabled())
+                .thenReturn(true);
+        when(maxComputeSinkConfig.getMaxComputeCompressionAlgorithm())
+                .thenReturn(CompressOption.CompressAlgorithm.ODPS_RAW);
+        when(maxComputeSinkConfig.getMaxComputeCompressionLevel())
+                .thenReturn(1);
+        when(maxComputeSinkConfig.getMaxComputeCompressionStrategy())
+                .thenReturn(1);
+        when(maxComputeSinkConfig.getStreamingInsertMaximumSessionCount())
+                .thenReturn(1);
+        when(maxComputeSinkConfig.getStreamingInsertTunnelSlotCountPerSession())
+                .thenReturn(1L);
+        RecordWrapper firstPartitionRecordWrapper = Mockito.mock(RecordWrapper.class);
+        when(firstPartitionRecordWrapper.getPartitionSpec())
+                .thenReturn(new PartitionSpec("ds=1"));
+        RecordWrapper secondPartitionRecordWrapper = Mockito.mock(RecordWrapper.class);
+        when(secondPartitionRecordWrapper.getPartitionSpec())
+                .thenReturn(new PartitionSpec("ds=2"));
+        List<RecordWrapper> recordWrappers = Arrays.asList(
+                firstPartitionRecordWrapper,
+                secondPartitionRecordWrapper
+        );
+        doNothing()
+                .when(instrumentation)
+                .captureCount(Mockito.anyString(), Mockito.anyLong());
+        StreamingSessionManager streamingSessionManager = Mockito.spy(StreamingSessionManager.createPartitioned(
+                tableTunnel, maxComputeSinkConfig, instrumentation, Mockito.mock(MaxComputeMetrics.class)
+        ));
+        PartitionedInsertManager partitionedInsertManager = new PartitionedInsertManager(maxComputeSinkConfig,
+                instrumentation, Mockito.mock(MaxComputeMetrics.class), streamingSessionManager);
+
+        partitionedInsertManager.insert(recordWrappers);
+    }
+
+    @Test(expected = IOException.class)
+    public void shouldRefreshSessionWhenIOExceptionOccurredDuringRecordFlush() throws IOException, TunnelException {
+        TableTunnel.FlushResult flushResult = Mockito.mock(TableTunnel.FlushResult.class);
+        when(flushResult.getRecordCount())
+                .thenReturn(2L);
+        TableTunnel.StreamRecordPack streamRecordPack = Mockito.mock(TableTunnel.StreamRecordPack.class);
+        TableTunnel.StreamUploadSession streamUploadSession = Mockito.spy(TableTunnel.StreamUploadSession.class);
+        doThrow(new IOException()).when(streamRecordPack).flush(Mockito.any());
+        ArgumentCaptor<CompressOption> compressOptionArgumentCaptor = ArgumentCaptor.forClass(CompressOption.class);
+        when(streamUploadSession.newRecordPack(compressOptionArgumentCaptor.capture()))
+                .thenReturn(streamRecordPack);
+        Mockito.doNothing()
                 .when(streamRecordPack)
                 .append(Mockito.any());
         when(streamRecordPack.flush())

--- a/src/test/java/com/gotocompany/depot/maxcompute/converter/DurationProtobufMaxComputeConverterTest.java
+++ b/src/test/java/com/gotocompany/depot/maxcompute/converter/DurationProtobufMaxComputeConverterTest.java
@@ -28,7 +28,7 @@ public class DurationProtobufMaxComputeConverterTest {
 
         TypeInfo typeInfo = durationProtobufMaxComputeConverter.convertTypeInfo(fieldDescriptor);
 
-        assertEquals("STRUCT<`seconds`:BIGINT,`nanos`:INT>", typeInfo.getTypeName());
+        assertEquals("STRUCT<seconds:BIGINT,nanos:INT>", typeInfo.getTypeName());
     }
 
     @Test

--- a/src/test/java/com/gotocompany/depot/maxcompute/converter/MessageProtobufMaxComputeConverterTest.java
+++ b/src/test/java/com/gotocompany/depot/maxcompute/converter/MessageProtobufMaxComputeConverterTest.java
@@ -44,7 +44,7 @@ public class MessageProtobufMaxComputeConverterTest {
         TypeInfo firstMessageFieldTypeInfo = messageProtobufMaxComputeConverter.convertTypeInfo(descriptor.getFields().get(1));
         TypeInfo secondMessageFieldTypeInfo = messageProtobufMaxComputeConverter.convertTypeInfo(descriptor.getFields().get(2));
 
-        String expectedFirstMessageTypeRepresentation = "STRUCT<`string_field`:STRING,`another_inner_field`:STRUCT<`string_field`:STRING>,`another_inner_list_field`:ARRAY<STRUCT<`string_field`:STRING>>>";
+        String expectedFirstMessageTypeRepresentation = "STRUCT<string_field:STRING,another_inner_field:STRUCT<string_field:STRING>,another_inner_list_field:ARRAY<STRUCT<string_field:STRING>>>";
         String expectedSecondMessageTypeRepresentation = String.format("ARRAY<%s>", expectedFirstMessageTypeRepresentation);
 
         assertEquals(expectedFirstMessageTypeRepresentation, firstMessageFieldTypeInfo.toString());

--- a/src/test/java/com/gotocompany/depot/maxcompute/converter/ProtobufConverterOrchestratorTest.java
+++ b/src/test/java/com/gotocompany/depot/maxcompute/converter/ProtobufConverterOrchestratorTest.java
@@ -48,10 +48,10 @@ public class ProtobufConverterOrchestratorTest {
     @Test
     public void shouldConvertPayloadToTypeInfo() {
         String expectedStringTypeInfoRepresentation = "STRING";
-        String expectedMessageTypeRepresentation = "STRUCT<`string_field`:STRING,`another_inner_field`:STRUCT<`string_field`:STRING>,`another_inner_list_field`:ARRAY<STRUCT<`string_field`:STRING>>>";
+        String expectedMessageTypeRepresentation = "STRUCT<string_field:STRING,another_inner_field:STRUCT<string_field:STRING>,another_inner_list_field:ARRAY<STRUCT<string_field:STRING>>>";
         String expectedRepeatedMessageTypeRepresentation = String.format("ARRAY<%s>", expectedMessageTypeRepresentation);
         String expectedTimestampTypeInfoRepresentation = "TIMESTAMP_NTZ";
-        String expectedDurationTypeInfoRepresentation = "STRUCT<`seconds`:BIGINT,`nanos`:INT>";
+        String expectedDurationTypeInfoRepresentation = "STRUCT<seconds:BIGINT,nanos:INT>";
         String expectedStructTypeInfoRepresentation = "STRING";
 
         TypeInfo stringTypeInfo = protobufConverterOrchestrator.toMaxComputeTypeInfo(descriptor.findFieldByName("string_field"));

--- a/src/test/java/com/gotocompany/depot/maxcompute/util/SchemaDifferenceUtilsTest.java
+++ b/src/test/java/com/gotocompany/depot/maxcompute/util/SchemaDifferenceUtilsTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -39,17 +40,19 @@ public class SchemaDifferenceUtilsTest {
                         .build())
                 .build();
         Set<String> expectedMetadataColumns = new HashSet<>(Arrays.asList(
-                "ALTER TABLE test_schema.test_table ADD COLUMN IF NOT EXISTS `col3`.`f3` ARRAY<STRING>;",
-                "ALTER TABLE test_schema.test_table ADD COLUMN IF NOT EXISTS `col4`.element.`f42` STRUCT<`f421`:STRING>;",
-                "ALTER TABLE test_schema.test_table ADD COLUMN IF NOT EXISTS `col5` ARRAY<STRUCT<`f51`:INT>>;",
-                "ALTER TABLE test_schema.test_table ADD COLUMN IF NOT EXISTS `col6` STRUCT<`f61`:STRING>;",
-                "ALTER TABLE test_schema.test_table ADD COLUMN IF NOT EXISTS `metadata_2` STRING;"
+                "ALTER TABLE test_schema.test_table ADD COLUMN IF NOT EXISTS col3.f3 ARRAY<STRING>;",
+                "ALTER TABLE test_schema.test_table ADD COLUMN IF NOT EXISTS col4.element.f42 STRUCT<f421:STRING>;",
+                "ALTER TABLE test_schema.test_table ADD COLUMN IF NOT EXISTS col5 ARRAY<STRUCT<f51:INT>>;",
+                "ALTER TABLE test_schema.test_table ADD COLUMN IF NOT EXISTS col6 STRUCT<f61:STRING>;",
+                "ALTER TABLE test_schema.test_table ADD COLUMN IF NOT EXISTS metadata_2 STRING;"
         ));
 
         Set<String> actualMetadataColumns = new HashSet<>(SchemaDifferenceUtils.getSchemaDifferenceSql(oldTableSchema, newTableSchema, "test_schema", "test_table"));
 
         assertEquals(actualMetadataColumns.size(), expectedMetadataColumns.size());
-        assertTrue(actualMetadataColumns.containsAll(expectedMetadataColumns));
+        assertTrue(expectedMetadataColumns.containsAll(actualMetadataColumns.stream()
+                .map(s -> s.replace("`", ""))
+                .collect(Collectors.toSet())));
     }
 
 }


### PR DESCRIPTION
Handle schema mismatch as non-retryable error in MaxCompute InsertManager (to handle multi pod schema update inconsistencies) 
Refresh session on network partition issue in MaxCompute InsertManager