### PR TITLE
Feat: Add Proto Float to MaxCompute double converter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
 }
 
 group 'com.gotocompany'
-version '0.10.4'
+version '0.10.5'
 
 repositories {
     mavenLocal()

--- a/docs/reference/configuration/maxcompute.md
+++ b/docs/reference/configuration/maxcompute.md
@@ -270,6 +270,15 @@ Otherwise proto integer types will be converted to corresponding MaxCompute type
 * Type: `required`
 * Default value: `false`
 
+## SINK_MAXCOMPUTE_PROTO_FLOAT_TYPE_TO_DOUBLE_ENABLED
+
+Configuration for enabling the conversion of proto float types to double. This config will be used for enabling the conversion of proto float types to MaxCompute double ( 64 bit ).
+This configuration takes precedence over the SINK_MAXCOMPUTE_PROTO_FLOAT_TYPE_TO_DECIMAL_ENABLED configuration. 
+
+* Example value: `true`
+* Type: `required`
+* Default value: `false`
+
 ## SINK_MAXCOMPUTE_PROTO_FLOAT_TYPE_TO_DECIMAL_ENABLED
 
 Configuration for enabling the conversion of proto float types to maxcompute decimal. There are possibilities of precision loss when using plain float type in MaxCompute.

--- a/src/main/java/com/gotocompany/depot/config/MaxComputeSinkConfig.java
+++ b/src/main/java/com/gotocompany/depot/config/MaxComputeSinkConfig.java
@@ -159,6 +159,10 @@ public interface MaxComputeSinkConfig extends Config {
     @DefaultValue("false")
     boolean isProtoFloatTypeToDecimalEnabled();
 
+    @Key("SINK_MAXCOMPUTE_PROTO_FLOAT_TYPE_TO_DOUBLE_ENABLED")
+    @DefaultValue("false")
+    boolean isProtoFloatTypeToDoubleEnabled();
+
     @Key("SINK_MAXCOMPUTE_PROTO_FLOAT_TYPE_TO_DECIMAL_PRECISION")
     @DefaultValue("38")
     int getProtoFloatToDecimalPrecision();

--- a/src/main/java/com/gotocompany/depot/maxcompute/converter/mapper/ProtoPrimitiveDataTypeMapperFactory.java
+++ b/src/main/java/com/gotocompany/depot/maxcompute/converter/mapper/ProtoPrimitiveDataTypeMapperFactory.java
@@ -7,6 +7,7 @@ import com.google.protobuf.Descriptors;
 import com.gotocompany.depot.config.MaxComputeSinkConfig;
 import com.gotocompany.depot.maxcompute.converter.mapper.casted.DoubleToDecimalDataTypeMapper;
 import com.gotocompany.depot.maxcompute.converter.mapper.casted.FloatToDecimalDataTypeMapper;
+import com.gotocompany.depot.maxcompute.converter.mapper.casted.FloatToDoubleDataTypeMapper;
 import com.gotocompany.depot.maxcompute.converter.mapper.casted.IntegerToBigintDataTypeMapper;
 import com.gotocompany.depot.maxcompute.converter.mapper.noncasted.DoubleDataTypeMapper;
 import com.gotocompany.depot.maxcompute.converter.mapper.noncasted.FloatDataTypeMapper;
@@ -29,8 +30,12 @@ public class ProtoPrimitiveDataTypeMapperFactory {
     public ProtoPrimitiveDataTypeMapperFactory(MaxComputeSinkConfig maxComputeSinkConfig) {
         this.nonNumericDataTypeMapper = new NonNumericDataTypeMapper();
         this.integerProtoPrimitiveDataTypeMapper = maxComputeSinkConfig.isProtoIntegerTypesToBigintEnabled() ? new IntegerToBigintDataTypeMapper() : new IntegerDataTypeMapper();
-        this.floatProtoPrimitiveDataTypeMapper = maxComputeSinkConfig.isProtoFloatTypeToDecimalEnabled() ? new FloatToDecimalDataTypeMapper(maxComputeSinkConfig) : new FloatDataTypeMapper();
         this.doubleProtoPrimitiveDataTypeMapper = maxComputeSinkConfig.isProtoDoubleToDecimalEnabled() ? new DoubleToDecimalDataTypeMapper(maxComputeSinkConfig) : new DoubleDataTypeMapper();
+        if (maxComputeSinkConfig.isProtoFloatTypeToDoubleEnabled()) {
+            this.floatProtoPrimitiveDataTypeMapper = new FloatToDoubleDataTypeMapper();
+        } else {
+            this.floatProtoPrimitiveDataTypeMapper = maxComputeSinkConfig.isProtoFloatTypeToDecimalEnabled() ? new FloatToDecimalDataTypeMapper(maxComputeSinkConfig) : new FloatDataTypeMapper();
+        }
     }
 
     public Map<Descriptors.FieldDescriptor.Type, TypeInfo> getProtoTypeMap() {

--- a/src/main/java/com/gotocompany/depot/maxcompute/converter/mapper/casted/FloatToDoubleDataTypeMapper.java
+++ b/src/main/java/com/gotocompany/depot/maxcompute/converter/mapper/casted/FloatToDoubleDataTypeMapper.java
@@ -1,0 +1,35 @@
+package com.gotocompany.depot.maxcompute.converter.mapper.casted;
+
+import com.aliyun.odps.type.TypeInfo;
+import com.aliyun.odps.type.TypeInfoFactory;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.Descriptors;
+import com.gotocompany.depot.exception.InvalidMessageException;
+import com.gotocompany.depot.maxcompute.converter.mapper.ProtoPrimitiveDataTypeMapper;
+
+import java.util.Map;
+import java.util.function.Function;
+
+public class FloatToDoubleDataTypeMapper implements ProtoPrimitiveDataTypeMapper {
+
+    @Override
+    public Map<Descriptors.FieldDescriptor.Type, TypeInfo> getProtoTypeMap() {
+        return ImmutableMap.of(
+                Descriptors.FieldDescriptor.Type.FLOAT, TypeInfoFactory.DOUBLE
+        );
+    }
+
+    @Override
+    public Map<Descriptors.FieldDescriptor.Type, Function<Object, Object>> getProtoPayloadMapperMap() {
+        return ImmutableMap.of(
+                Descriptors.FieldDescriptor.Type.FLOAT, object -> isValid((float) object)
+        );
+    }
+
+    private double isValid(float value) {
+        if (!Float.isFinite(value)) {
+            throw new InvalidMessageException("Invalid float value: " + value);
+        }
+        return Double.parseDouble(Float.toString(value));
+    }
+}

--- a/src/test/java/com/gotocompany/depot/maxcompute/converter/mapper/ProtoPrimitiveDataTypeMapperFactoryTest.java
+++ b/src/test/java/com/gotocompany/depot/maxcompute/converter/mapper/ProtoPrimitiveDataTypeMapperFactoryTest.java
@@ -70,4 +70,36 @@ public class ProtoPrimitiveDataTypeMapperFactoryTest {
         Assertions.assertEquals(TypeInfoFactory.BIGINT, protoTypeToOdpsTypeMap.get(Descriptors.FieldDescriptor.Type.SINT64));
         Assertions.assertEquals(TypeInfoFactory.BIGINT, protoTypeToOdpsTypeMap.get(Descriptors.FieldDescriptor.Type.SINT32));
     }
+
+    @Test
+    public void shouldReturnCustomImplementationWithFloatToDouble() {
+        MaxComputeSinkConfig maxComputeSinkConfig = Mockito.mock(MaxComputeSinkConfig.class);
+        Mockito.when(maxComputeSinkConfig.isProtoIntegerTypesToBigintEnabled()).thenReturn(true);
+        int precision = 38;
+        int scale = 18;
+        Mockito.when(maxComputeSinkConfig.isProtoFloatTypeToDoubleEnabled()).thenReturn(true);
+        Mockito.when(maxComputeSinkConfig.isProtoDoubleToDecimalEnabled()).thenReturn(true);
+        Mockito.when(maxComputeSinkConfig.getProtoDoubleToDecimalPrecision()).thenReturn(precision);
+        Mockito.when(maxComputeSinkConfig.getProtoDoubleToDecimalScale()).thenReturn(scale);
+        Mockito.when(maxComputeSinkConfig.getDecimalRoundingMode()).thenReturn(RoundingMode.UNNECESSARY);
+        ProtoPrimitiveDataTypeMapperFactory protoPrimitiveDataTypeMapperFactory = new ProtoPrimitiveDataTypeMapperFactory(maxComputeSinkConfig);
+
+        Map<Descriptors.FieldDescriptor.Type, TypeInfo> protoTypeToOdpsTypeMap = protoPrimitiveDataTypeMapperFactory.getProtoTypeMap();
+
+        Assertions.assertEquals(TypeInfoFactory.BIGINT, protoTypeToOdpsTypeMap.get(Descriptors.FieldDescriptor.Type.INT32));
+        Assertions.assertEquals(TypeInfoFactory.BIGINT, protoTypeToOdpsTypeMap.get(Descriptors.FieldDescriptor.Type.INT64));
+        Assertions.assertEquals(TypeInfoFactory.STRING, protoTypeToOdpsTypeMap.get(Descriptors.FieldDescriptor.Type.STRING));
+        Assertions.assertEquals(TypeInfoFactory.getDecimalTypeInfo(precision, scale), protoTypeToOdpsTypeMap.get(Descriptors.FieldDescriptor.Type.DOUBLE));
+        Assertions.assertEquals(TypeInfoFactory.DOUBLE, protoTypeToOdpsTypeMap.get(Descriptors.FieldDescriptor.Type.FLOAT));
+        Assertions.assertEquals(TypeInfoFactory.BINARY, protoTypeToOdpsTypeMap.get(Descriptors.FieldDescriptor.Type.BYTES));
+        Assertions.assertEquals(TypeInfoFactory.BIGINT, protoTypeToOdpsTypeMap.get(Descriptors.FieldDescriptor.Type.UINT64));
+        Assertions.assertEquals(TypeInfoFactory.BIGINT, protoTypeToOdpsTypeMap.get(Descriptors.FieldDescriptor.Type.UINT32));
+        Assertions.assertEquals(TypeInfoFactory.BIGINT, protoTypeToOdpsTypeMap.get(Descriptors.FieldDescriptor.Type.FIXED64));
+        Assertions.assertEquals(TypeInfoFactory.BIGINT, protoTypeToOdpsTypeMap.get(Descriptors.FieldDescriptor.Type.FIXED32));
+        Assertions.assertEquals(TypeInfoFactory.BIGINT, protoTypeToOdpsTypeMap.get(Descriptors.FieldDescriptor.Type.SFIXED64));
+        Assertions.assertEquals(TypeInfoFactory.BIGINT, protoTypeToOdpsTypeMap.get(Descriptors.FieldDescriptor.Type.SFIXED32));
+        Assertions.assertEquals(TypeInfoFactory.BIGINT, protoTypeToOdpsTypeMap.get(Descriptors.FieldDescriptor.Type.SINT64));
+        Assertions.assertEquals(TypeInfoFactory.BIGINT, protoTypeToOdpsTypeMap.get(Descriptors.FieldDescriptor.Type.SINT32));
+    }
+
 }

--- a/src/test/java/com/gotocompany/depot/maxcompute/converter/mapper/casted/FloatToDoubleDataTypeMapperTest.java
+++ b/src/test/java/com/gotocompany/depot/maxcompute/converter/mapper/casted/FloatToDoubleDataTypeMapperTest.java
@@ -1,0 +1,62 @@
+package com.gotocompany.depot.maxcompute.converter.mapper.casted;
+
+import com.aliyun.odps.type.TypeInfo;
+import com.aliyun.odps.type.TypeInfoFactory;
+import com.google.protobuf.Descriptors;
+import com.gotocompany.depot.exception.InvalidMessageException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class FloatToDoubleDataTypeMapperTest {
+
+    private final FloatToDoubleDataTypeMapper floatToDoubleDataTypeMapper = new FloatToDoubleDataTypeMapper();
+
+    @Test
+    public void shouldReturnDoubleMaxComputeType() {
+        TypeInfo typeInfo = floatToDoubleDataTypeMapper.getProtoTypeMap()
+                .get(Descriptors.FieldDescriptor.Type.FLOAT);
+
+        assertEquals(TypeInfoFactory.DOUBLE, typeInfo);
+    }
+
+    @Test
+    public void shouldReturnValidFloatValue() {
+        float input = Float.MIN_VALUE;
+        double expected = Double.parseDouble(Float.toString(Float.MIN_VALUE));
+        Object result = floatToDoubleDataTypeMapper.getProtoPayloadMapperMap()
+                .get(Descriptors.FieldDescriptor.Type.FLOAT)
+                .apply(input);
+
+        assertTrue(result instanceof Double);
+        assertEquals(expected, (double) result, 0);
+    }
+
+    @Test(expected = InvalidMessageException.class)
+    public void shouldThrowInvalidMessageExceptionWhenFloatValueIsPositiveInfinity() {
+        float input = Float.POSITIVE_INFINITY;
+
+        floatToDoubleDataTypeMapper.getProtoPayloadMapperMap()
+                .get(Descriptors.FieldDescriptor.Type.FLOAT)
+                .apply(input);
+    }
+
+    @Test(expected = InvalidMessageException.class)
+    public void shouldThrowInvalidMessageExceptionWhenFloatValueIsNegativeInfinity() {
+        float input = Float.NEGATIVE_INFINITY;
+
+        floatToDoubleDataTypeMapper.getProtoPayloadMapperMap()
+                .get(Descriptors.FieldDescriptor.Type.FLOAT)
+                .apply(input);
+    }
+
+    @Test(expected = InvalidMessageException.class)
+    public void shouldThrowInvalidMessageExceptionWhenFloatValueIsNaN() {
+        float input = Float.NaN;
+
+        floatToDoubleDataTypeMapper.getProtoPayloadMapperMap()
+                .get(Descriptors.FieldDescriptor.Type.FLOAT)
+                .apply(input);
+    }
+}


### PR DESCRIPTION
Context: 
- MMS will convert BQ's float ( 64 bit ) to MaxCompute double ( 64 bit )
- Need to make sure that table created by Firehose will be compatible to be backfilled by MMS
