### PR TITLE
fix: Negative nano handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
 }
 
 group 'com.gotocompany'
-version '0.10.6'
+version '0.10.7'
 
 repositories {
     mavenLocal()

--- a/docs/reference/configuration/maxcompute.md
+++ b/docs/reference/configuration/maxcompute.md
@@ -347,3 +347,17 @@ The format of this config is `key1=value1,key2=value2,...`. Further documentatio
 * Example value: `table.format.version=2`
 * Type: `optional`
 * Default value: ``
+
+## SINK_MAXCOMPUTE_NANO_HANDLING_ENABLED
+
+This configuration is used to handle nano data values. Its default value is true.
+
+If it is enabled:
+1. If nano is less than 0, it will be set to 0.
+2. If nano exceeds its range (> 999,999,999), the extra value will be added to the seconds.
+
+If it is disabled and nano is outside the default range, firehose will crash.
+
+* Example value: `true`
+* Type: `optional`
+* Default value: `true`

--- a/src/main/java/com/gotocompany/depot/config/MaxComputeSinkConfig.java
+++ b/src/main/java/com/gotocompany/depot/config/MaxComputeSinkConfig.java
@@ -193,7 +193,7 @@ public interface MaxComputeSinkConfig extends Config {
     Map<String, String> getTableProperties();
 
     @Key("SINK_MAXCOMPUTE_NANO_HANDLING_ENABLED")
-    @DefaultValue("false")
+    @DefaultValue("true")
     boolean isNanoHandlingEnabled();
 
 }

--- a/src/main/java/com/gotocompany/depot/config/MaxComputeSinkConfig.java
+++ b/src/main/java/com/gotocompany/depot/config/MaxComputeSinkConfig.java
@@ -192,4 +192,8 @@ public interface MaxComputeSinkConfig extends Config {
     @DefaultValue("")
     Map<String, String> getTableProperties();
 
+    @Key("SINK_MAXCOMPUTE_NANO_HANDLING_ENABLED")
+    @DefaultValue("false")
+    boolean isNanoHandlingEnabled();
+
 }

--- a/src/main/java/com/gotocompany/depot/maxcompute/util/LocalDateTimeValidator.java
+++ b/src/main/java/com/gotocompany/depot/maxcompute/util/LocalDateTimeValidator.java
@@ -41,9 +41,12 @@ public class LocalDateTimeValidator {
 
     public LocalDateTime parseAndValidate(long seconds, int nanos, String fieldName, boolean isRootLevel) {
         if (isNanoHandlingEnabled) {
-                long[] adjustedValues = adjustNanos(seconds, nanos);
-                seconds = adjustedValues[0];
-                nanos = (int) adjustedValues[1];
+            if (nanos < 0) {
+                nanos = 0;
+            } else if (nanos >= NANOS_IN_ONE_SECOND) {
+                seconds += nanos / NANOS_IN_ONE_SECOND;
+                nanos = nanos % NANOS_IN_ONE_SECOND;
+            }
         }
         Instant instant = Instant.now();
         ZoneOffset zoneOffset = zoneId.getRules().getOffset(instant);
@@ -51,16 +54,6 @@ public class LocalDateTimeValidator {
         validateTimestampRange(localDateTime);
         validateTimestampPartitionKey(fieldName, localDateTime, isRootLevel);
         return localDateTime;
-    }
-
-    private long[] adjustNanos(long seconds, int nanos) {
-        if (nanos < 0) {
-            return new long[]{seconds, 0};
-        } else if (nanos >= NANOS_IN_ONE_SECOND) {
-            seconds += nanos / NANOS_IN_ONE_SECOND;
-            nanos = nanos % NANOS_IN_ONE_SECOND;
-        }
-        return new long[]{seconds, nanos};
     }
 
     private void validateTimestampRange(LocalDateTime localDateTime) {

--- a/src/main/java/com/gotocompany/depot/maxcompute/util/LocalDateTimeValidator.java
+++ b/src/main/java/com/gotocompany/depot/maxcompute/util/LocalDateTimeValidator.java
@@ -13,6 +13,7 @@ import java.time.temporal.TemporalAmount;
 public class LocalDateTimeValidator {
 
     private static final long DAYS_IN_YEAR = 365L;
+    private static final int NANOS_IN_ONE_SECOND = 1_000_000_000;
 
     private final TemporalAmount maxPastEventTimeDifference;
     private final TemporalAmount maxFutureEventTimeDifference;
@@ -23,6 +24,7 @@ public class LocalDateTimeValidator {
     private final String tablePartitionKey;
     private final int maxPastYearEventTimeDifference;
     private final int maxFutureYearEventTimeDifference;
+    private final boolean isNanoHandlingEnabled;
 
     public LocalDateTimeValidator(MaxComputeSinkConfig maxComputeSinkConfig) {
         this.maxPastEventTimeDifference = Duration.ofDays(maxComputeSinkConfig.getMaxPastYearEventTimeDifference() * DAYS_IN_YEAR);
@@ -34,9 +36,20 @@ public class LocalDateTimeValidator {
         this.tablePartitionKey = maxComputeSinkConfig.getTablePartitionKey();
         this.maxPastYearEventTimeDifference = maxComputeSinkConfig.getMaxPastYearEventTimeDifference();
         this.maxFutureYearEventTimeDifference = maxComputeSinkConfig.getMaxFutureYearEventTimeDifference();
+        this.isNanoHandlingEnabled = maxComputeSinkConfig.isNanoHandlingEnabled();
     }
 
     public LocalDateTime parseAndValidate(long seconds, int nanos, String fieldName, boolean isRootLevel) {
+
+        if (isNanoHandlingEnabled) {
+            if (nanos < 0) {
+                nanos = 0;
+            } else if (nanos > NANOS_IN_ONE_SECOND) {
+                int extraSeconds = nanos / NANOS_IN_ONE_SECOND;
+                seconds += extraSeconds;
+                nanos = nanos % NANOS_IN_ONE_SECOND;
+            }
+        }
         Instant instant = Instant.now();
         ZoneOffset zoneOffset = zoneId.getRules().getOffset(instant);
         LocalDateTime localDateTime = LocalDateTime.ofEpochSecond(seconds, nanos, zoneOffset);

--- a/src/test/java/com/gotocompany/depot/maxcompute/converter/TimestampNTZProtobufMaxComputeConverterTest.java
+++ b/src/test/java/com/gotocompany/depot/maxcompute/converter/TimestampNTZProtobufMaxComputeConverterTest.java
@@ -336,7 +336,7 @@ public class TimestampNTZProtobufMaxComputeConverterTest {
 
         Timestamp timestamp = Timestamp.newBuilder()
                 .setSeconds(2500)
-                .setNanos(1_000_000_000)
+                .setNanos(1_500_000_000)
                 .build();
         TestMaxComputeTypeInfo.TestRoot message = TestMaxComputeTypeInfo.TestRoot.newBuilder()
                 .setTimestampField(timestamp)
@@ -345,6 +345,6 @@ public class TimestampNTZProtobufMaxComputeConverterTest {
         Object result = timestampNtzProtobufMaxComputeConverter.convertSingularPayload(
                 new ProtoPayload(descriptor.getFields().get(3), message.getField(descriptor.getFields().get(3)), true));
 
-        assertThat(result).isEqualTo(LocalDateTime.ofEpochSecond(2501, 0, ZoneOffset.UTC));
+        assertThat(result).isEqualTo(LocalDateTime.ofEpochSecond(2501, 500000000, ZoneOffset.UTC));
     }
 }

--- a/src/test/java/com/gotocompany/depot/maxcompute/converter/TimestampProtobufMaxComputeConverterTest.java
+++ b/src/test/java/com/gotocompany/depot/maxcompute/converter/TimestampProtobufMaxComputeConverterTest.java
@@ -244,14 +244,14 @@ public class TimestampProtobufMaxComputeConverterTest {
 
         Timestamp timestamp = Timestamp.newBuilder()
                 .setSeconds(2500)
-                .setNanos(1000000000)
+                .setNanos(1500000000)
                 .build();
         TestMaxComputeTypeInfo.TestRoot message = TestMaxComputeTypeInfo.TestRoot.newBuilder()
                 .setTimestampField(timestamp)
                 .build();
 
         java.sql.Timestamp expectedTimestamp = java.sql.Timestamp.valueOf(LocalDateTime.ofEpochSecond(
-                timestamp.getSeconds() + 1, 0, ZoneOffset.UTC));
+                timestamp.getSeconds() + 1, 500000000, ZoneOffset.UTC));
         Object result = timestampProtobufMaxComputeConverter.convertSingularPayload(new ProtoPayload(descriptor.getFields().get(3), message.getField(descriptor.getFields().get(3)), true));
         assertThat(result).isEqualTo(expectedTimestamp);
     }

--- a/src/test/java/com/gotocompany/depot/maxcompute/converter/TimestampProtobufMaxComputeConverterTest.java
+++ b/src/test/java/com/gotocompany/depot/maxcompute/converter/TimestampProtobufMaxComputeConverterTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mockito;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
@@ -230,4 +231,113 @@ public class TimestampProtobufMaxComputeConverterTest {
 
         assertThat(result).isEqualTo(expectedTimestamp);
     }
+
+    @Test
+    public void shouldConvertExcessNanosToSecondsWhenEnabled() {
+        MaxComputeSinkConfig maxComputeSinkConfig = Mockito.mock(MaxComputeSinkConfig.class);
+        when(maxComputeSinkConfig.getZoneId()).thenReturn(ZoneId.of("UTC"));
+        when(maxComputeSinkConfig.isTablePartitioningEnabled()).thenReturn(true);
+        when(maxComputeSinkConfig.getValidMinTimestamp()).thenReturn(LocalDateTime.parse("1970-01-01T00:00:00", DateTimeFormatter.ISO_DATE_TIME));
+        when(maxComputeSinkConfig.getValidMaxTimestamp()).thenReturn(LocalDateTime.parse("9999-01-01T23:59:59", DateTimeFormatter.ISO_DATE_TIME));
+        when(maxComputeSinkConfig.isNanoHandlingEnabled()).thenReturn(true);
+        timestampProtobufMaxComputeConverter = new TimestampProtobufMaxComputeConverter(maxComputeSinkConfig);
+
+        Timestamp timestamp = Timestamp.newBuilder()
+                .setSeconds(2500)
+                .setNanos(1000000000)
+                .build();
+        TestMaxComputeTypeInfo.TestRoot message = TestMaxComputeTypeInfo.TestRoot.newBuilder()
+                .setTimestampField(timestamp)
+                .build();
+
+        java.sql.Timestamp expectedTimestamp = java.sql.Timestamp.valueOf(LocalDateTime.ofEpochSecond(
+                timestamp.getSeconds() + 1, 0, ZoneOffset.UTC));
+        Object result = timestampProtobufMaxComputeConverter.convertSingularPayload(new ProtoPayload(descriptor.getFields().get(3), message.getField(descriptor.getFields().get(3)), true));
+        assertThat(result).isEqualTo(expectedTimestamp);
+    }
+
+    @Test(expected = java.time.DateTimeException.class)
+    public void shouldThrowExceptionForExcessNanosWhenDisabled() {
+        MaxComputeSinkConfig maxComputeSinkConfig = Mockito.mock(MaxComputeSinkConfig.class);
+        when(maxComputeSinkConfig.getZoneId()).thenReturn(ZoneId.of("UTC"));
+        when(maxComputeSinkConfig.isTablePartitioningEnabled()).thenReturn(false);
+        when(maxComputeSinkConfig.getValidMinTimestamp()).thenReturn(LocalDateTime.parse("1970-01-01T00:00:00", DateTimeFormatter.ISO_DATE_TIME));
+        when(maxComputeSinkConfig.getValidMaxTimestamp()).thenReturn(LocalDateTime.parse("9999-01-01T23:59:59", DateTimeFormatter.ISO_DATE_TIME));
+        when(maxComputeSinkConfig.isNanoHandlingEnabled()).thenReturn(false);
+        timestampProtobufMaxComputeConverter = new TimestampProtobufMaxComputeConverter(maxComputeSinkConfig);
+
+        Timestamp timestamp = Timestamp.newBuilder()
+                .setSeconds(2500)
+                .setNanos(1000000000)
+                .build();
+        TestMaxComputeTypeInfo.TestRoot message = TestMaxComputeTypeInfo.TestRoot.newBuilder()
+                .setTimestampField(timestamp)
+                .build();
+
+        timestampProtobufMaxComputeConverter.convertSingularPayload(new ProtoPayload(descriptor.getFields().get(3), message.getField(descriptor.getFields().get(3)), true));
+    }
+
+    @Test(expected = java.time.DateTimeException.class)
+    public void shouldThrowExceptionForNegativeNanosWhenDisabled() {
+        MaxComputeSinkConfig maxComputeSinkConfig = Mockito.mock(MaxComputeSinkConfig.class);
+        when(maxComputeSinkConfig.getZoneId()).thenReturn(ZoneId.of("UTC"));
+        when(maxComputeSinkConfig.isTablePartitioningEnabled()).thenReturn(false);
+        when(maxComputeSinkConfig.getValidMinTimestamp()).thenReturn(LocalDateTime.parse("1970-01-01T00:00:00", DateTimeFormatter.ISO_DATE_TIME));
+        when(maxComputeSinkConfig.getValidMaxTimestamp()).thenReturn(LocalDateTime.parse("9999-01-01T23:59:59", DateTimeFormatter.ISO_DATE_TIME));
+        when(maxComputeSinkConfig.isNanoHandlingEnabled()).thenReturn(false);
+        timestampProtobufMaxComputeConverter = new TimestampProtobufMaxComputeConverter(maxComputeSinkConfig);
+
+        Timestamp timestamp = Timestamp.newBuilder()
+                .setSeconds(2500)
+                .setNanos(-1)
+                .build();
+        TestMaxComputeTypeInfo.TestRoot message = TestMaxComputeTypeInfo.TestRoot.newBuilder()
+                .setTimestampField(timestamp)
+                .build();
+
+        timestampProtobufMaxComputeConverter.convertSingularPayload(new ProtoPayload(descriptor.getFields().get(3), message.getField(descriptor.getFields().get(3)), true));
+    }
+
+    @Test
+    public void shouldHandleNegativeNanosWhenEnabled() {
+        MaxComputeSinkConfig maxComputeSinkConfig = Mockito.mock(MaxComputeSinkConfig.class);
+        when(maxComputeSinkConfig.getZoneId()).thenReturn(ZoneId.of("UTC"));
+        when(maxComputeSinkConfig.isTablePartitioningEnabled()).thenReturn(true);
+        when(maxComputeSinkConfig.getValidMinTimestamp()).thenReturn(LocalDateTime.parse("1970-01-01T00:00:00", DateTimeFormatter.ISO_DATE_TIME));
+        when(maxComputeSinkConfig.getValidMaxTimestamp()).thenReturn(LocalDateTime.parse("9999-01-01T23:59:59", DateTimeFormatter.ISO_DATE_TIME));
+        when(maxComputeSinkConfig.isNanoHandlingEnabled()).thenReturn(true);
+        timestampProtobufMaxComputeConverter = new TimestampProtobufMaxComputeConverter(maxComputeSinkConfig);
+
+        Timestamp timestamp = Timestamp.newBuilder()
+                .setSeconds(2500)
+                .setNanos(-500000000)  // Negative nanoseconds
+                .build();
+        TestMaxComputeTypeInfo.TestRoot message = TestMaxComputeTypeInfo.TestRoot.newBuilder()
+                .setTimestampField(timestamp)
+                .build();
+
+        java.sql.Timestamp expectedTimestamp = java.sql.Timestamp.valueOf(LocalDateTime.ofEpochSecond(
+                timestamp.getSeconds(), 0, ZoneOffset.UTC));
+
+        Object result = timestampProtobufMaxComputeConverter.convertSingularPayload(new ProtoPayload(descriptor.getFields().get(3), message.getField(descriptor.getFields().get(3)), true));
+
+        assertThat(result).isEqualTo(expectedTimestamp);
+    }
+
+    @Test
+    public void shouldConvertPayloadWithValidNanos() {
+        Timestamp timestamp = Timestamp.newBuilder()
+                .setSeconds(2500)
+                .setNanos(500000000)
+                .build();
+        TestMaxComputeTypeInfo.TestRoot message = TestMaxComputeTypeInfo.TestRoot.newBuilder()
+                .setTimestampField(timestamp)
+                .build();
+        java.sql.Timestamp expectedTimestamp = java.sql.Timestamp.valueOf(LocalDateTime.ofEpochSecond(
+                timestamp.getSeconds(), timestamp.getNanos(), ZoneOffset.UTC));
+
+        Object result = timestampProtobufMaxComputeConverter.convertSingularPayload(new ProtoPayload(descriptor.getFields().get(3), message.getField(descriptor.getFields().get(3)), true));
+        assertThat(result).isEqualTo(expectedTimestamp);
+    }
+
 }


### PR DESCRIPTION
Added one config SINK_MAXCOMPUTE_NANO_HANDLING_ENABLED to handle data values which exceeds nano range.
Its default value is true.