### PR TITLE
[Fix] MaxCompute Fix Empty Proto Message Handling - Negative Second Timestamp

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
 }
 
 group 'com.gotocompany'
-version '0.10.11'
+version '0.10.12'
 
 repositories {
     mavenLocal()

--- a/docs/reference/configuration/maxcompute.md
+++ b/docs/reference/configuration/maxcompute.md
@@ -371,3 +371,11 @@ Value set should be more than 0.
 * Example value: `15`
 * Type: `optional`
 * Default value: `15`
+
+## SINK_MAXCOMPUTE_IGNORE_NEGATIVE_SECOND_TIMESTAMP_ENABLED
+
+This configuration is to ignore the negative second timestamp. If it is enabled, the negative second timestamp will be set to null.
+
+* Example value: `false`
+* Type: `optional`
+* Default value: `true`

--- a/src/main/java/com/gotocompany/depot/config/MaxComputeSinkConfig.java
+++ b/src/main/java/com/gotocompany/depot/config/MaxComputeSinkConfig.java
@@ -200,4 +200,7 @@ public interface MaxComputeSinkConfig extends Config {
     @DefaultValue("15")
     int getMaxNestedMessageDepth();
 
+    @Key("SINK_MAXCOMPUTE_IGNORE_NEGATIVE_SECOND_TIMESTAMP")
+    @DefaultValue("true")
+    boolean isIgnoreNegativeSecondTimestampEnabled();
 }

--- a/src/main/java/com/gotocompany/depot/config/MaxComputeSinkConfig.java
+++ b/src/main/java/com/gotocompany/depot/config/MaxComputeSinkConfig.java
@@ -200,7 +200,7 @@ public interface MaxComputeSinkConfig extends Config {
     @DefaultValue("15")
     int getMaxNestedMessageDepth();
 
-    @Key("SINK_MAXCOMPUTE_IGNORE_NEGATIVE_SECOND_TIMESTAMP")
+    @Key("SINK_MAXCOMPUTE_IGNORE_NEGATIVE_SECOND_TIMESTAMP_ENABLED")
     @DefaultValue("true")
     boolean isIgnoreNegativeSecondTimestampEnabled();
 }

--- a/src/main/java/com/gotocompany/depot/maxcompute/converter/TimestampNTZProtobufMaxComputeConverter.java
+++ b/src/main/java/com/gotocompany/depot/maxcompute/converter/TimestampNTZProtobufMaxComputeConverter.java
@@ -7,10 +7,6 @@ import com.gotocompany.depot.config.MaxComputeSinkConfig;
 import com.gotocompany.depot.maxcompute.model.ProtoPayload;
 import com.gotocompany.depot.maxcompute.util.LocalDateTimeValidator;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
 /**
  * Converts protobuf timestamp to LocalDateTime.
  * LocalDateTime is the java compatible type for TIMESTAMP_NTZ type used in MaxCompute.
@@ -32,17 +28,6 @@ public class TimestampNTZProtobufMaxComputeConverter implements ProtobufMaxCompu
     @Override
     public TypeInfo convertSingularTypeInfo(ProtoPayload protoPayload) {
         return TypeInfoFactory.TIMESTAMP_NTZ;
-    }
-
-    @Override
-    public Object convertPayload(ProtoPayload protoPayload) {
-        if (!protoPayload.getFieldDescriptor().isRepeated()) {
-            return convertSingularPayload(protoPayload);
-        }
-        return ((List<?>) protoPayload.getParsedObject()).stream()
-                .map(o -> convertSingularPayload(new ProtoPayload(protoPayload.getFieldDescriptor(), o, protoPayload.getLevel())))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/com/gotocompany/depot/maxcompute/converter/TimestampNTZProtobufMaxComputeConverter.java
+++ b/src/main/java/com/gotocompany/depot/maxcompute/converter/TimestampNTZProtobufMaxComputeConverter.java
@@ -7,6 +7,10 @@ import com.gotocompany.depot.config.MaxComputeSinkConfig;
 import com.gotocompany.depot.maxcompute.model.ProtoPayload;
 import com.gotocompany.depot.maxcompute.util.LocalDateTimeValidator;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
 /**
  * Converts protobuf timestamp to LocalDateTime.
  * LocalDateTime is the java compatible type for TIMESTAMP_NTZ type used in MaxCompute.
@@ -28,6 +32,17 @@ public class TimestampNTZProtobufMaxComputeConverter implements ProtobufMaxCompu
     @Override
     public TypeInfo convertSingularTypeInfo(ProtoPayload protoPayload) {
         return TypeInfoFactory.TIMESTAMP_NTZ;
+    }
+
+    @Override
+    public Object convertPayload(ProtoPayload protoPayload) {
+        if (!protoPayload.getFieldDescriptor().isRepeated()) {
+            return convertSingularPayload(protoPayload);
+        }
+        return ((List<?>) protoPayload.getParsedObject()).stream()
+                .map(o -> convertSingularPayload(new ProtoPayload(protoPayload.getFieldDescriptor(), o, protoPayload.getLevel())))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/com/gotocompany/depot/maxcompute/converter/TimestampProtobufMaxComputeConverter.java
+++ b/src/main/java/com/gotocompany/depot/maxcompute/converter/TimestampProtobufMaxComputeConverter.java
@@ -8,9 +8,6 @@ import com.gotocompany.depot.maxcompute.model.ProtoPayload;
 import com.gotocompany.depot.maxcompute.util.LocalDateTimeValidator;
 
 import java.sql.Timestamp;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 public class TimestampProtobufMaxComputeConverter implements ProtobufMaxComputeConverter {
 
@@ -23,17 +20,6 @@ public class TimestampProtobufMaxComputeConverter implements ProtobufMaxComputeC
     public TimestampProtobufMaxComputeConverter(MaxComputeSinkConfig maxComputeSinkConfig) {
         this.localDateTimeValidator = new LocalDateTimeValidator(maxComputeSinkConfig);
         this.isIgnoreNegativeSecondTimestampEnabled = maxComputeSinkConfig.isIgnoreNegativeSecondTimestampEnabled();
-    }
-
-    @Override
-    public Object convertPayload(ProtoPayload protoPayload) {
-        if (!protoPayload.getFieldDescriptor().isRepeated()) {
-            return convertSingularPayload(protoPayload);
-        }
-        return ((List<?>) protoPayload.getParsedObject()).stream()
-                .map(o -> convertSingularPayload(new ProtoPayload(protoPayload.getFieldDescriptor(), o, protoPayload.getLevel())))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/com/gotocompany/depot/maxcompute/converter/TimestampProtobufMaxComputeConverter.java
+++ b/src/main/java/com/gotocompany/depot/maxcompute/converter/TimestampProtobufMaxComputeConverter.java
@@ -8,6 +8,9 @@ import com.gotocompany.depot.maxcompute.model.ProtoPayload;
 import com.gotocompany.depot.maxcompute.util.LocalDateTimeValidator;
 
 import java.sql.Timestamp;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class TimestampProtobufMaxComputeConverter implements ProtobufMaxComputeConverter {
 
@@ -20,6 +23,17 @@ public class TimestampProtobufMaxComputeConverter implements ProtobufMaxComputeC
     public TimestampProtobufMaxComputeConverter(MaxComputeSinkConfig maxComputeSinkConfig) {
         this.localDateTimeValidator = new LocalDateTimeValidator(maxComputeSinkConfig);
         this.isIgnoreNegativeSecondTimestampEnabled = maxComputeSinkConfig.isIgnoreNegativeSecondTimestampEnabled();
+    }
+
+    @Override
+    public Object convertPayload(ProtoPayload protoPayload) {
+        if (!protoPayload.getFieldDescriptor().isRepeated()) {
+            return convertSingularPayload(protoPayload);
+        }
+        return ((List<?>) protoPayload.getParsedObject()).stream()
+                .map(o -> convertSingularPayload(new ProtoPayload(protoPayload.getFieldDescriptor(), o, protoPayload.getLevel())))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/com/gotocompany/depot/maxcompute/util/LocalDateTimeValidator.java
+++ b/src/main/java/com/gotocompany/depot/maxcompute/util/LocalDateTimeValidator.java
@@ -2,7 +2,6 @@ package com.gotocompany.depot.maxcompute.util;
 
 import com.gotocompany.depot.config.MaxComputeSinkConfig;
 import com.gotocompany.depot.exception.InvalidMessageException;
-import lombok.extern.slf4j.Slf4j;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -11,7 +10,6 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.temporal.TemporalAmount;
 
-@Slf4j
 public class LocalDateTimeValidator {
 
     private static final long DAYS_IN_YEAR = 365L;
@@ -55,7 +53,6 @@ public class LocalDateTimeValidator {
         LocalDateTime localDateTime = LocalDateTime.ofEpochSecond(seconds, nanos, zoneOffset);
         validateTimestampRange(localDateTime);
         validateTimestampPartitionKey(fieldName, localDateTime, isRootLevel);
-        log.info("Field name : {} Timestamp seconds: {} nanos: {} parsed to LocalDateTime: {}", fieldName, seconds, nanos, localDateTime);
         return localDateTime;
     }
 

--- a/src/main/java/com/gotocompany/depot/maxcompute/util/LocalDateTimeValidator.java
+++ b/src/main/java/com/gotocompany/depot/maxcompute/util/LocalDateTimeValidator.java
@@ -2,6 +2,7 @@ package com.gotocompany.depot.maxcompute.util;
 
 import com.gotocompany.depot.config.MaxComputeSinkConfig;
 import com.gotocompany.depot.exception.InvalidMessageException;
+import lombok.extern.slf4j.Slf4j;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -10,6 +11,7 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.temporal.TemporalAmount;
 
+@Slf4j
 public class LocalDateTimeValidator {
 
     private static final long DAYS_IN_YEAR = 365L;
@@ -53,6 +55,7 @@ public class LocalDateTimeValidator {
         LocalDateTime localDateTime = LocalDateTime.ofEpochSecond(seconds, nanos, zoneOffset);
         validateTimestampRange(localDateTime);
         validateTimestampPartitionKey(fieldName, localDateTime, isRootLevel);
+        log.info("Field name : {} Timestamp seconds: {} nanos: {} parsed to LocalDateTime: {}", fieldName, seconds, nanos, localDateTime);
         return localDateTime;
     }
 

--- a/src/test/java/com/gotocompany/depot/maxcompute/converter/TimestampNTZProtobufMaxComputeConverterTest.java
+++ b/src/test/java/com/gotocompany/depot/maxcompute/converter/TimestampNTZProtobufMaxComputeConverterTest.java
@@ -42,6 +42,7 @@ public class TimestampNTZProtobufMaxComputeConverterTest {
         when(maxComputeSinkConfig.getTablePartitionKey()).thenReturn("timestamp_field");
         when(maxComputeSinkConfig.getMaxPastYearEventTimeDifference()).thenReturn(999);
         when(maxComputeSinkConfig.getMaxFutureYearEventTimeDifference()).thenReturn(999);
+        when(maxComputeSinkConfig.isIgnoreNegativeSecondTimestampEnabled()).thenReturn(false);
         timestampNtzProtobufMaxComputeConverter = new TimestampNTZProtobufMaxComputeConverter(maxComputeSinkConfig);
     }
 
@@ -346,5 +347,49 @@ public class TimestampNTZProtobufMaxComputeConverterTest {
                 new ProtoPayload(descriptor.getFields().get(3), message.getField(descriptor.getFields().get(3)), 0));
 
         assertThat(result).isEqualTo(LocalDateTime.ofEpochSecond(2501, 500000000, ZoneOffset.UTC));
+    }
+
+    @Test
+    public void shouldConvertPayloadToNullWhenSecondsIsNegativeWhenFlagIsEnabled() {
+        MaxComputeSinkConfig maxComputeSinkConfig = Mockito.mock(MaxComputeSinkConfig.class);
+        when(maxComputeSinkConfig.getZoneId()).thenReturn(ZoneId.of("UTC"));
+        when(maxComputeSinkConfig.getValidMinTimestamp()).thenReturn(LocalDateTime.parse("1970-01-01T00:00:01", DateTimeFormatter.ISO_DATE_TIME));
+        when(maxComputeSinkConfig.getValidMaxTimestamp()).thenReturn(LocalDateTime.parse("9999-01-01T23:59:59", DateTimeFormatter.ISO_DATE_TIME));
+        when(maxComputeSinkConfig.isTablePartitioningEnabled()).thenReturn(true);
+        when(maxComputeSinkConfig.getTablePartitionKey()).thenReturn("timestamp_field");
+        when(maxComputeSinkConfig.getMaxPastYearEventTimeDifference()).thenReturn(999);
+        when(maxComputeSinkConfig.getMaxFutureYearEventTimeDifference()).thenReturn(999);
+        when(maxComputeSinkConfig.isIgnoreNegativeSecondTimestampEnabled()).thenReturn(true);
+        timestampNtzProtobufMaxComputeConverter = new TimestampNTZProtobufMaxComputeConverter(maxComputeSinkConfig);
+        Timestamp timestamp = Timestamp.newBuilder()
+                .setSeconds(-1000L)
+                .setNanos(2)
+                .build();
+
+        Object result = timestampNtzProtobufMaxComputeConverter.convertSingularPayload(new ProtoPayload(descriptor.getFields().get(3), timestamp, 0));
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void shouldConvertPayloadToTimestampWhenSecondsIsNegativeWhenFlagIsNotEnabled() {
+        MaxComputeSinkConfig maxComputeSinkConfig = Mockito.mock(MaxComputeSinkConfig.class);
+        when(maxComputeSinkConfig.getZoneId()).thenReturn(ZoneId.of("UTC"));
+        when(maxComputeSinkConfig.getValidMinTimestamp()).thenReturn(LocalDateTime.parse("0001-01-01T00:00:01", DateTimeFormatter.ISO_DATE_TIME));
+        when(maxComputeSinkConfig.getValidMaxTimestamp()).thenReturn(LocalDateTime.parse("9999-01-01T23:59:59", DateTimeFormatter.ISO_DATE_TIME));
+        when(maxComputeSinkConfig.isTablePartitioningEnabled()).thenReturn(true);
+        when(maxComputeSinkConfig.getTablePartitionKey()).thenReturn("timestamp_field");
+        when(maxComputeSinkConfig.getMaxPastYearEventTimeDifference()).thenReturn(999);
+        when(maxComputeSinkConfig.getMaxFutureYearEventTimeDifference()).thenReturn(999);
+        when(maxComputeSinkConfig.isIgnoreNegativeSecondTimestampEnabled()).thenReturn(false);
+        timestampNtzProtobufMaxComputeConverter = new TimestampNTZProtobufMaxComputeConverter(maxComputeSinkConfig);
+        Timestamp timestamp = Timestamp.newBuilder()
+                .setSeconds(-1000L)
+                .setNanos(2)
+                .build();
+
+        Object result = timestampNtzProtobufMaxComputeConverter.convertSingularPayload(new ProtoPayload(descriptor.getFields().get(3), timestamp, 0));
+
+        assertThat(result).isEqualTo(LocalDateTime.ofEpochSecond(-1000L, 2, ZoneOffset.UTC));
     }
 }


### PR DESCRIPTION
Fix : 
- Initially when message being polled contains empty proto message, all batch of message will fail and mapped to DEFAULT_ERROR. This fix will make individual empty message mapped to INVALID_MESSAGE_ERROR accordingly
- To make MC Depot comply with BQ Depot, we add the flag to ignore timestamp with negative seconds and map it to null value