### PR TITLE
[fix] Add flag to process negative second timestamp as null

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
 }
 
 group 'com.gotocompany'
-version '0.10.11'
+version '0.10.12'
 
 repositories {
     mavenLocal()

--- a/docs/reference/configuration/maxcompute.md
+++ b/docs/reference/configuration/maxcompute.md
@@ -371,3 +371,11 @@ Value set should be more than 0.
 * Example value: `15`
 * Type: `optional`
 * Default value: `15`
+
+## SINK_MAXCOMPUTE_IGNORE_NEGATIVE_SECOND_TIMESTAMP_ENABLED
+
+This configuration is to ignore the negative second timestamp. If it is enabled, the negative second timestamp will be set to null.
+
+* Example value: `false`
+* Type: `optional`
+* Default value: `true`

--- a/src/main/java/com/gotocompany/depot/config/MaxComputeSinkConfig.java
+++ b/src/main/java/com/gotocompany/depot/config/MaxComputeSinkConfig.java
@@ -200,4 +200,7 @@ public interface MaxComputeSinkConfig extends Config {
     @DefaultValue("15")
     int getMaxNestedMessageDepth();
 
+    @Key("SINK_MAXCOMPUTE_IGNORE_NEGATIVE_SECOND_TIMESTAMP_ENABLED")
+    @DefaultValue("true")
+    boolean isIgnoreNegativeSecondTimestampEnabled();
 }

--- a/src/test/java/com/gotocompany/depot/maxcompute/converter/TimestampNTZProtobufMaxComputeConverterTest.java
+++ b/src/test/java/com/gotocompany/depot/maxcompute/converter/TimestampNTZProtobufMaxComputeConverterTest.java
@@ -42,6 +42,7 @@ public class TimestampNTZProtobufMaxComputeConverterTest {
         when(maxComputeSinkConfig.getTablePartitionKey()).thenReturn("timestamp_field");
         when(maxComputeSinkConfig.getMaxPastYearEventTimeDifference()).thenReturn(999);
         when(maxComputeSinkConfig.getMaxFutureYearEventTimeDifference()).thenReturn(999);
+        when(maxComputeSinkConfig.isIgnoreNegativeSecondTimestampEnabled()).thenReturn(false);
         timestampNtzProtobufMaxComputeConverter = new TimestampNTZProtobufMaxComputeConverter(maxComputeSinkConfig);
     }
 
@@ -346,5 +347,49 @@ public class TimestampNTZProtobufMaxComputeConverterTest {
                 new ProtoPayload(descriptor.getFields().get(3), message.getField(descriptor.getFields().get(3)), 0));
 
         assertThat(result).isEqualTo(LocalDateTime.ofEpochSecond(2501, 500000000, ZoneOffset.UTC));
+    }
+
+    @Test
+    public void shouldConvertPayloadToNullWhenSecondsIsNegativeWhenFlagIsEnabled() {
+        MaxComputeSinkConfig maxComputeSinkConfig = Mockito.mock(MaxComputeSinkConfig.class);
+        when(maxComputeSinkConfig.getZoneId()).thenReturn(ZoneId.of("UTC"));
+        when(maxComputeSinkConfig.getValidMinTimestamp()).thenReturn(LocalDateTime.parse("1970-01-01T00:00:01", DateTimeFormatter.ISO_DATE_TIME));
+        when(maxComputeSinkConfig.getValidMaxTimestamp()).thenReturn(LocalDateTime.parse("9999-01-01T23:59:59", DateTimeFormatter.ISO_DATE_TIME));
+        when(maxComputeSinkConfig.isTablePartitioningEnabled()).thenReturn(true);
+        when(maxComputeSinkConfig.getTablePartitionKey()).thenReturn("timestamp_field");
+        when(maxComputeSinkConfig.getMaxPastYearEventTimeDifference()).thenReturn(999);
+        when(maxComputeSinkConfig.getMaxFutureYearEventTimeDifference()).thenReturn(999);
+        when(maxComputeSinkConfig.isIgnoreNegativeSecondTimestampEnabled()).thenReturn(true);
+        timestampNtzProtobufMaxComputeConverter = new TimestampNTZProtobufMaxComputeConverter(maxComputeSinkConfig);
+        Timestamp timestamp = Timestamp.newBuilder()
+                .setSeconds(-1000L)
+                .setNanos(2)
+                .build();
+
+        Object result = timestampNtzProtobufMaxComputeConverter.convertSingularPayload(new ProtoPayload(descriptor.getFields().get(3), timestamp, 0));
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void shouldConvertPayloadToTimestampWhenSecondsIsNegativeWhenFlagIsNotEnabled() {
+        MaxComputeSinkConfig maxComputeSinkConfig = Mockito.mock(MaxComputeSinkConfig.class);
+        when(maxComputeSinkConfig.getZoneId()).thenReturn(ZoneId.of("UTC"));
+        when(maxComputeSinkConfig.getValidMinTimestamp()).thenReturn(LocalDateTime.parse("0001-01-01T00:00:01", DateTimeFormatter.ISO_DATE_TIME));
+        when(maxComputeSinkConfig.getValidMaxTimestamp()).thenReturn(LocalDateTime.parse("9999-01-01T23:59:59", DateTimeFormatter.ISO_DATE_TIME));
+        when(maxComputeSinkConfig.isTablePartitioningEnabled()).thenReturn(true);
+        when(maxComputeSinkConfig.getTablePartitionKey()).thenReturn("timestamp_field");
+        when(maxComputeSinkConfig.getMaxPastYearEventTimeDifference()).thenReturn(999);
+        when(maxComputeSinkConfig.getMaxFutureYearEventTimeDifference()).thenReturn(999);
+        when(maxComputeSinkConfig.isIgnoreNegativeSecondTimestampEnabled()).thenReturn(false);
+        timestampNtzProtobufMaxComputeConverter = new TimestampNTZProtobufMaxComputeConverter(maxComputeSinkConfig);
+        Timestamp timestamp = Timestamp.newBuilder()
+                .setSeconds(-1000L)
+                .setNanos(2)
+                .build();
+
+        Object result = timestampNtzProtobufMaxComputeConverter.convertSingularPayload(new ProtoPayload(descriptor.getFields().get(3), timestamp, 0));
+
+        assertThat(result).isEqualTo(LocalDateTime.ofEpochSecond(-1000L, 2, ZoneOffset.UTC));
     }
 }


### PR DESCRIPTION
Make MC depot comply with BQ implementation where timestamp with negative **seconds** is mapped as null value