### PR TITLE
[fix] skip fields with empty string representation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
 }
 
 group 'com.gotocompany'
-version '0.10.14'
+version '0.10.15'
 
 repositories {
     mavenLocal()

--- a/src/main/java/com/gotocompany/depot/maxcompute/converter/MessageProtobufMaxComputeConverter.java
+++ b/src/main/java/com/gotocompany/depot/maxcompute/converter/MessageProtobufMaxComputeConverter.java
@@ -71,6 +71,10 @@ public class MessageProtobufMaxComputeConverter implements ProtobufMaxComputeCon
                 .stream()
                 .filter(fd -> shouldIncludeField(protoPayload, fd))
                 .forEach(innerFieldDescriptor -> {
+                    if (dynamicMessage.getField(innerFieldDescriptor).toString().isEmpty()) {
+                        values.add(null);
+                        return;
+                    }
                     if (ProtoUtils.isNonRepeatedProtoMessage(innerFieldDescriptor) && !dynamicMessage.hasField(innerFieldDescriptor)) {
                         values.add(null);
                         return;

--- a/src/main/java/com/gotocompany/depot/maxcompute/record/ProtoDataColumnRecordDecorator.java
+++ b/src/main/java/com/gotocompany/depot/maxcompute/record/ProtoDataColumnRecordDecorator.java
@@ -98,6 +98,9 @@ public class ProtoDataColumnRecordDecorator extends RecordDecorator {
                     if (fieldDescriptor.getName().equals(partitionFieldName) && shouldReplaceOriginalColumn) {
                         return;
                     }
+                    if (protoMessage.getField(fieldDescriptor).toString().isEmpty()) {
+                        return;
+                    }
                     if (ProtoUtils.isNonRepeatedProtoMessage(fieldDescriptor) && !protoMessage.hasField(fieldDescriptor)) {
                         return;
                     }


### PR DESCRIPTION
<img width="1382" alt="image" src="https://github.com/user-attachments/assets/711c19b0-9407-41d5-9fae-24ace0b6add1" />
Need to cater same logic, simply using hasField is not sufficient since proto message can be set with empty message explicitly from producer side. See the image below for example on producer setting empty message explicitly

<img width="680" alt="image" src="https://github.com/user-attachments/assets/08b28950-a788-4c59-8d4e-9a058b4213ec" />
