### PR TITLE
Add schema label in maxcompute sink metrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ plugins {
 }
 
 group 'com.gotocompany'
-version '0.10.21'
+version '0.10.22'
 
 repositories {
     mavenLocal()

--- a/src/main/java/com/gotocompany/depot/maxcompute/client/ddl/DdlManager.java
+++ b/src/main/java/com/gotocompany/depot/maxcompute/client/ddl/DdlManager.java
@@ -127,6 +127,7 @@ public class DdlManager {
                 maxComputeMetrics.getMaxComputeOperationTotalMetric(),
                 String.format(MaxComputeMetrics.MAXCOMPUTE_TABLE_TAG, maxComputeSinkConfig.getMaxComputeTableName()),
                 String.format(MaxComputeMetrics.MAXCOMPUTE_PROJECT_TAG, maxComputeSinkConfig.getMaxComputeProjectId()),
+                String.format(MaxComputeMetrics.MAXCOMPUTE_SCHEMA_TAG, maxComputeSinkConfig.getMaxComputeSchema()),
                 String.format(MaxComputeMetrics.MAXCOMPUTE_API_TAG, type)
         );
         instrumentation.captureDurationSince(
@@ -134,6 +135,7 @@ public class DdlManager {
                 startTime,
                 String.format(MaxComputeMetrics.MAXCOMPUTE_TABLE_TAG, maxComputeSinkConfig.getMaxComputeTableName()),
                 String.format(MaxComputeMetrics.MAXCOMPUTE_PROJECT_TAG, maxComputeSinkConfig.getMaxComputeProjectId()),
+                String.format(MaxComputeMetrics.MAXCOMPUTE_SCHEMA_TAG, maxComputeSinkConfig.getMaxComputeSchema()),
                 String.format(MaxComputeMetrics.MAXCOMPUTE_API_TAG, type)
         );
     }

--- a/src/main/java/com/gotocompany/depot/metrics/MaxComputeMetrics.java
+++ b/src/main/java/com/gotocompany/depot/metrics/MaxComputeMetrics.java
@@ -7,6 +7,7 @@ public class MaxComputeMetrics extends SinkMetrics {
     public static final String MAXCOMPUTE_SINK_PREFIX = "maxcompute_";
     public static final String MAXCOMPUTE_TABLE_TAG = "table=%s";
     public static final String MAXCOMPUTE_PROJECT_TAG = "project=%s";
+    public static final String MAXCOMPUTE_SCHEMA_TAG = "schema=%s";
     public static final String MAXCOMPUTE_API_TAG = "api=%s";
     public static final String MAXCOMPUTE_ERROR_TAG = "error=%s";
     public static final String MAXCOMPUTE_COMPRESSION_TAG = "compression=%s-%s";


### PR DESCRIPTION
- Add new label `schema={schema name}` in the maxcompute sink metrics that sends `project` name.